### PR TITLE
fix: CI test failures

### DIFF
--- a/src/qortex/cli/project.py
+++ b/src/qortex/cli/project.py
@@ -28,7 +28,11 @@ def _get_backend():
         return backend
     except Exception as e:
         import sys
-        print(f"Warning: Could not connect to Memgraph ({e}), using empty InMemoryBackend", file=sys.stderr)
+
+        print(
+            f"Warning: Could not connect to Memgraph ({e}), using empty InMemoryBackend",
+            file=sys.stderr,
+        )
         from qortex.core.memory import InMemoryBackend
 
         backend = InMemoryBackend()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,8 +100,9 @@ class TestConfig:
         config = QortexConfig()
         assert config.memgraph_host == "localhost"
         assert config.memgraph_port == 7687
-        assert config.memgraph_credentials.user == "qortex"
-        assert config.memgraph_credentials.auth_tuple == ("qortex", "qortex")
+        # Default matches docker-compose defaults
+        assert config.memgraph_credentials.user == "memgraph"
+        assert config.memgraph_credentials.auth_tuple == ("memgraph", "memgraph")
         assert config.lab_port == 3000
 
     def test_config_from_env(self):
@@ -239,72 +240,92 @@ class TestIngest:
 # =========================================================================
 
 
+def _mock_empty_backend():
+    """Return an empty InMemoryBackend for testing."""
+    from qortex.core.memory import InMemoryBackend
+
+    backend = InMemoryBackend()
+    backend.connect()
+    return backend
+
+
 class TestProjectBuildlog:
     def test_buildlog_empty_graph(self):
-        result = runner.invoke(app, ["project", "buildlog"])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            result = runner.invoke(app, ["project", "buildlog"])
         assert result.exit_code == 0
         parsed = yaml.safe_load(result.output)
         assert parsed["rules"] == []
         assert parsed["persona"] == "qortex"
 
     def test_buildlog_custom_persona(self):
-        result = runner.invoke(app, ["project", "buildlog", "--persona", "custom"])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            result = runner.invoke(app, ["project", "buildlog", "--persona", "custom"])
         assert result.exit_code == 0
         parsed = yaml.safe_load(result.output)
         assert parsed["persona"] == "custom"
 
     def test_buildlog_no_enrich(self):
-        result = runner.invoke(app, ["project", "buildlog", "--no-enrich"])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            result = runner.invoke(app, ["project", "buildlog", "--no-enrich"])
         assert result.exit_code == 0
 
     def test_buildlog_to_file(self, tmp_path):
-        output = tmp_path / "seed.yml"
-        result = runner.invoke(app, ["project", "buildlog", "--output", str(output)])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            output = tmp_path / "seed.yml"
+            result = runner.invoke(app, ["project", "buildlog", "--output", str(output)])
         assert result.exit_code == 0
         assert output.exists()
         parsed = yaml.safe_load(output.read_text())
         assert "rules" in parsed
 
     def test_buildlog_domain_filter(self):
-        result = runner.invoke(app, ["project", "buildlog", "--domain", "test"])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            result = runner.invoke(app, ["project", "buildlog", "--domain", "test"])
         assert result.exit_code == 0
 
 
 class TestProjectFlat:
     def test_flat_empty_graph(self):
-        result = runner.invoke(app, ["project", "flat"])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            result = runner.invoke(app, ["project", "flat"])
         assert result.exit_code == 0
         parsed = yaml.safe_load(result.output)
         assert parsed["rules"] == []
 
     def test_flat_to_file(self, tmp_path):
-        output = tmp_path / "rules.yml"
-        result = runner.invoke(app, ["project", "flat", "--output", str(output)])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            output = tmp_path / "rules.yml"
+            result = runner.invoke(app, ["project", "flat", "--output", str(output)])
         assert result.exit_code == 0
         assert output.exists()
 
     def test_flat_no_enrich(self):
-        result = runner.invoke(app, ["project", "flat", "--no-enrich"])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            result = runner.invoke(app, ["project", "flat", "--no-enrich"])
         assert result.exit_code == 0
 
 
 class TestProjectJSON:
     def test_json_empty_graph(self):
-        result = runner.invoke(app, ["project", "json"])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            result = runner.invoke(app, ["project", "json"])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["rules"] == []
 
     def test_json_to_file(self, tmp_path):
-        output = tmp_path / "rules.json"
-        result = runner.invoke(app, ["project", "json", "--output", str(output)])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            output = tmp_path / "rules.json"
+            result = runner.invoke(app, ["project", "json", "--output", str(output)])
         assert result.exit_code == 0
         assert output.exists()
         parsed = json.loads(output.read_text())
         assert "rules" in parsed
 
     def test_json_no_enrich(self):
-        result = runner.invoke(app, ["project", "json", "--no-enrich"])
+        with patch("qortex.cli.project._get_backend", _mock_empty_backend):
+            result = runner.invoke(app, ["project", "json", "--no-enrich"])
         assert result.exit_code == 0
 
 

--- a/tests/test_e2e_book_to_buildlog.py
+++ b/tests/test_e2e_book_to_buildlog.py
@@ -667,7 +667,7 @@ class TestE2EWithMemgraph:
     def _setup_backend(self):
         from qortex.core.backend import MemgraphBackend, MemgraphCredentials
 
-        creds = MemgraphCredentials(user="qortex", password="qortex")
+        creds = MemgraphCredentials(user="memgraph", password="memgraph")
         self.backend = MemgraphBackend(uri="bolt://localhost:7687", credentials=creds)
         self.backend.connect()
         self.backend._run("MATCH (n) DETACH DELETE n")


### PR DESCRIPTION
## Summary
- Update test_default_config to expect "memgraph" credentials (matches docker-compose defaults)
- Add `_mock_empty_backend()` helper returning InMemoryBackend for project tests
- Patch `_get_backend` in project tests to avoid real Memgraph connections
- Fix E2E Memgraph test credentials from qortex/qortex to memgraph/memgraph

## Test plan
- [x] All 407 tests pass locally
- [x] 34 tests skipped (Memgraph integration tests without Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)