### PR TITLE
docs: update README + point LangChain case study to langchain-qortex

### DIFF
--- a/docs/tutorials/case-studies/langchain-vectorstore.md
+++ b/docs/tutorials/case-studies/langchain-vectorstore.md
@@ -1,224 +1,35 @@
-# Case Study: QortexVectorStore as a Drop-In for Chroma/FAISS
+# LangChain VectorStore Integration
 
-> **Status**: E2E proven in `tests/test_langchain_vectorstore.py` (38 tests) and `tests/test_langchain_e2e_dogfood.py` (14 tests)
->
-> **The hook**: `QortexVectorStore` IS a `VectorStore`. It works anywhere LangChain expects one: `similarity_search()`, `from_texts()`, `as_retriever()`, chains, agents. isinstance check passes. It also provides graph exploration, rules, and a feedback loop.
+`langchain-qortex` is a standalone package providing `QortexVectorStore`, a LangChain `VectorStore` backed by qortex's knowledge graph.
 
-## What LangChain Has
+## Install
 
-LangChain's `VectorStore` is the universal storage interface. Every vector database (Chroma, FAISS, Pinecone, Weaviate, Qdrant...) implements it. The API is standardized:
+```bash
+pip install langchain-qortex
+```
 
-| LangChain VectorStore | QortexVectorStore |
-|----------------------|-------------------|
-| `VectorStore.from_texts(texts, embedding)` | Same (zero-config setup) |
-| `vs.similarity_search(query, k)` | Same (returns `list[Document]`) |
-| `vs.similarity_search_with_score(query, k)` | Same (returns `list[tuple[Document, float]]`) |
-| `vs.add_texts(texts, metadatas)` | Same (incremental ingestion) |
-| `vs.as_retriever()` | Same (works in any LCEL chain) |
-| `vs.get_by_ids(ids)` | Same (fetch by node ID) |
-| (no equivalent) | `vs.explore(node_id)` |
-| (no equivalent) | `vs.rules(concept_ids=[...])` |
-| (no equivalent) | `vs.feedback({id: "accepted"})` |
-
-qortex implements the full VectorStore API and adds graph exploration, rule projection, and feedback-driven learning.
-
-## The Swap
-
-### One-liner (like Chroma.from_texts)
+## Quick start
 
 ```python
-# Before (Chroma):
-from langchain_chroma import Chroma
-vs = Chroma.from_texts(texts, embedding)
+from langchain_qortex import QortexVectorStore
 
-# After (qortex):
-from qortex.adapters.langchain_vectorstore import QortexVectorStore
+# Zero-config (like Chroma.from_texts)
 vs = QortexVectorStore.from_texts(texts, embedding, domain="security")
+docs = vs.similarity_search("authentication", k=5)
+retriever = vs.as_retriever()
 
-# Everything downstream stays the same
-docs = vs.similarity_search("authentication tokens", k=5)
-retriever = vs.as_retriever(search_kwargs={"k": 10})
-chain = retriever | format_docs | prompt | llm
+# qortex extras
+explore = vs.explore(docs[0].metadata["node_id"])
+rules = vs.rules(concept_ids=[d.metadata["node_id"] for d in docs])
+vs.feedback({docs[0].id: "accepted"})
 ```
 
-### From existing client (graph-enhanced)
+## Full documentation
 
-```python
-from qortex.client import LocalQortexClient
-from qortex.adapters.langchain_vectorstore import QortexVectorStore
+See the [langchain-qortex repository](https://github.com/Peleke/langchain-qortex) for the full VectorStore guide, including:
 
-# Client with graph + rules already set up
-client = LocalQortexClient(
-    vector_index=vector_index,
-    backend=backend,
-    embedding_model=embedding,
-    mode="graph",
-)
-
-vs = QortexVectorStore(client=client, domain="security")
-```
-
-## Standard VectorStore API
-
-### similarity_search
-
-```python
-docs = vs.similarity_search("OAuth2 authorization", k=3)
-for doc in docs:
-    print(doc.page_content)              # "OAuth2: OAuth2 authorization framework..."
-    print(doc.metadata["domain"])         # "security"
-    print(doc.metadata["node_id"])        # "sec:oauth":use for explore()
-    print(doc.metadata["score"])          # 0.94
-```
-
-### similarity_search_with_score
-
-```python
-results = vs.similarity_search_with_score("JWT tokens", k=3)
-for doc, score in results:
-    print(f"{score:.2f}: {doc.page_content}")
-# Scores are descending (most similar first)
-```
-
-### as_retriever
-
-```python
-retriever = vs.as_retriever(search_kwargs={"k": 5})
-docs = retriever.invoke("how to authenticate API requests")
-
-# Works in LCEL chains
-from langchain_core.runnables import RunnableLambda
-chain = retriever | RunnableLambda(lambda docs: "\n".join(d.page_content for d in docs))
-```
-
-### add_texts
-
-```python
-ids = vs.add_texts(
-    ["Zero-trust architecture assumes no implicit trust"],
-    metadatas=[{"source": "research-paper"}],
-)
-# New concepts are immediately searchable
-```
-
-## The Differentiators
-
-### Graph exploration from search results
-
-```python
-# 1. Search (standard VectorStore API)
-docs = vs.similarity_search("OAuth2 authorization", k=3)
-
-# 2. Explore (qortex extra)
-node_id = docs[0].metadata["node_id"]
-explore = vs.explore(node_id)
-
-# 3. See typed edges
-for edge in explore.edges:
-    print(f"{edge.source_id} --{edge.relation_type}--> {edge.target_id}")
-# sec:oauth --REQUIRES--> sec:jwt
-# sec:oauth --USES--> sec:rbac
-
-# 4. Navigate to neighbors
-for neighbor in explore.neighbors:
-    print(f"{neighbor.name}: {neighbor.description}")
-
-# 5. See linked rules
-for rule in explore.rules:
-    print(f"[{rule.category}] {rule.text}")
-```
-
-```mermaid
-graph TD
-    SEARCH["similarity_search('OAuth2')"] --> DOC["Document(metadata={node_id: 'sec:oauth'})"]
-    DOC --> EXPLORE["explore('sec:oauth')"]
-    EXPLORE --> EDGES["Typed edges:<br/>REQUIRES → JWT<br/>USES → RBAC"]
-    EXPLORE --> RULES["Rules:<br/>'Always use OAuth2 for<br/>third-party API access'"]
-    EXPLORE --> NEIGHBORS["Neighbors:<br/>JWT, RBAC, MFA"]
-
-    style SEARCH fill:#369,stroke:#333,color:#fff
-    style EXPLORE fill:#693,stroke:#333,color:#fff
-    style RULES fill:#963,stroke:#333,color:#fff
-```
-
-### Rules in query results
-
-Rules are auto-surfaced in Document metadata when concepts have linked rules:
-
-```python
-results = vs.similarity_search_with_score("OAuth2 authorization", k=4)
-for doc, score in results:
-    if "rules" in doc.metadata:
-        for rule in doc.metadata["rules"]:
-            print(f"  Rule: {rule['text']} (relevance: {rule['relevance']:.2f})")
-```
-
-### Rules projection
-
-```python
-# Get rules for all retrieved concepts
-activated = [doc.metadata["node_id"] for doc in docs]
-rules_result = vs.rules(concept_ids=activated)
-for rule in rules_result.rules:
-    print(f"[{rule.category}] {rule.text}")
-# [security] Always use OAuth2 for third-party API access
-# [operations] Rotate JWT signing keys every 90 days
-# [architectural] Define RBAC roles before writing authorization code
-```
-
-### Feedback loop
-
-```python
-# 1. Search
-docs = vs.similarity_search("authentication protocol", k=4)
-
-# 2. Use results in your application...
-
-# 3. Tell qortex what worked
-vs.feedback({
-    docs[0].id: "accepted",   # This was useful
-    docs[-1].id: "rejected",  # This was not
-})
-
-# 4. Future searches improve based on feedback
-docs2 = vs.similarity_search("authentication protocol", k=4)
-```
-
-In graph mode, feedback adjusts PPR teleportation factors. Accepted concepts get higher teleportation probability. The system learns which concepts are actually useful.
-
-## What We Proved
-
-| Claim | Evidence |
-|-------|----------|
-| Real VectorStore | `isinstance(vs, VectorStore)` is `True`. Not a duck type. |
-| from_texts() zero-config | One line creates a full backend, indexes texts, returns a ready VectorStore. |
-| as_retriever() works in chains | Pipe operators, RunnableParallel, the full LCEL composition system. |
-| Graph exploration | Search, take `node_id`, explore: typed edges + neighbors + rules. |
-| Rules auto-surfaced | query() includes rules in results with zero extra effort from the consumer. |
-| Feedback loop | search, outcomes, recorded, future searches adjust. |
-| JSON roundtrip | All results survive `json.dumps()`/`json.loads()` for serialization. |
-
-## What qortex Adds to LangChain
-
-LangChain's VectorStore unifies dozens of vector databases behind one API. qortex implements that same API and layers graph structure on top.
-
-| Dimension | Standard VectorStore (solid foundation) | QortexVectorStore (augmentation) |
-|-----------|----------------------------------------|--------------------------------|
-| Search | Cosine similarity | Vec + PPR combined scoring |
-| Structure | Flat documents | Typed edges (REQUIRES, USES...) |
-| Navigation | | `explore(node_id)` graph traversal |
-| Rules | | Auto-surfaced in results |
-| Feedback | | Outcomes → teleportation updates |
-| Learning | Static | Continuous improvement |
-| API | VectorStore ABC | Same VectorStore ABC |
-
-## Ejection Path
-
-QortexVectorStore is designed to be ejectable as a standalone `langchain-qortex` package (like `langchain-openai`, `langchain-chroma`). See [GitHub Issue #45](https://github.com/Peleke/qortex/issues/45) for the ejection plan.
-
-## Next Steps
-
-- [Querying Guide](../../guides/querying.md) (full query pipeline reference)
-- [BaseRetriever Integration](langchain-base-retriever.md) (lighter-weight retriever adapter)
-- [Mastra MCP](mastra-mcp-vector-store.md) (cross-language integration)
-- [API Reference](../../reference/api.md) (QortexClient protocol and types)
+- Standard VectorStore API (similarity_search, from_texts, as_retriever)
+- Graph exploration from search results
+- Rules auto-surfaced in query results
+- Feedback-driven learning loop
+- Evidence table of what's proven in E2E tests


### PR DESCRIPTION
## Summary
- README rewritten to reflect current state (graph-enhanced retrieval, framework adapters, MCP server, QortexClient API)
- LangChain VectorStore case study now points to standalone [langchain-qortex](https://github.com/Peleke/langchain-qortex) package

## Context
langchain-qortex ejected as standalone package per #45. 58 tests pass, 99% coverage. CI + PyPI publish workflows in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)