### PR TITLE
feat: Layer 2 Core — source adapter protocol, serializers, registry

### DIFF
--- a/src/qortex/sources/__init__.py
+++ b/src/qortex/sources/__init__.py
@@ -1,0 +1,37 @@
+"""Source adapters: connect external databases to qortex vec + graph layers.
+
+Architecture:
+    SourceAdapter protocol → connect/discover/read/sync → VectorIndex + GraphBackend
+    RowSerializer protocol → row dict → text for embedding
+
+Implementations:
+    PostgresSourceAdapter (async, via asyncpg) — PR 3
+    SqliteSourceAdapter (future)
+    MongoSourceAdapter (future)
+"""
+
+from qortex.sources.base import (
+    ColumnSchema,
+    SourceAdapter,
+    SourceConfig,
+    SyncResult,
+    TableSchema,
+)
+from qortex.sources.registry import SourceRegistry
+from qortex.sources.serializer import (
+    KeyValueSerializer,
+    NaturalLanguageSerializer,
+    RowSerializer,
+)
+
+__all__ = [
+    "ColumnSchema",
+    "KeyValueSerializer",
+    "NaturalLanguageSerializer",
+    "RowSerializer",
+    "SourceAdapter",
+    "SourceConfig",
+    "SourceRegistry",
+    "SyncResult",
+    "TableSchema",
+]

--- a/src/qortex/sources/base.py
+++ b/src/qortex/sources/base.py
@@ -1,0 +1,136 @@
+"""Core types and protocol for source adapters.
+
+SourceAdapter connects to an external database, discovers its schema,
+reads rows, and syncs them into qortex's vec + graph layers.
+
+All types here are pure dataclasses — no database drivers needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterator, Protocol, runtime_checkable
+
+
+@dataclass
+class ColumnSchema:
+    """Schema for a single database column."""
+
+    name: str
+    data_type: str  # e.g. "text", "integer", "uuid", "jsonb"
+    nullable: bool = True
+    is_pk: bool = False
+    is_fk: bool = False
+    foreign_table: str | None = None
+    foreign_column: str | None = None
+
+
+@dataclass
+class TableSchema:
+    """Schema for a database table."""
+
+    name: str
+    columns: list[ColumnSchema] = field(default_factory=list)
+    row_count: int = 0
+    schema_name: str = "public"
+
+    @property
+    def pk_columns(self) -> list[str]:
+        """Primary key column names."""
+        return [c.name for c in self.columns if c.is_pk]
+
+    @property
+    def fk_columns(self) -> list[ColumnSchema]:
+        """Foreign key columns."""
+        return [c for c in self.columns if c.is_fk]
+
+    @property
+    def full_name(self) -> str:
+        """schema.table qualified name."""
+        return f"{self.schema_name}.{self.name}"
+
+
+@dataclass
+class SyncResult:
+    """Result of syncing a source to qortex."""
+
+    source_id: str
+    tables_synced: int = 0
+    rows_added: int = 0
+    rows_updated: int = 0
+    rows_deleted: int = 0
+    vectors_created: int = 0
+    errors: list[str] = field(default_factory=list)
+    duration_seconds: float = 0.0
+
+
+@dataclass
+class SourceConfig:
+    """Configuration for connecting a source database.
+
+    domain_map maps glob patterns to domain names:
+        {"habits.*": "habits", "swae_movements.*": "exercise"}
+    If a table doesn't match any pattern, it maps to default_domain.
+    """
+
+    source_id: str
+    connection_string: str
+    schemas: list[str] = field(default_factory=lambda: ["public"])
+    tables: list[str] | None = None  # None = all tables
+    exclude_tables: list[str] = field(default_factory=list)
+    domain_map: dict[str, str] = field(default_factory=dict)
+    default_domain: str = "default"
+    serialize_strategy: str = "natural_language"  # or "key_value"
+    batch_size: int = 500
+
+    def resolve_domain(self, table_name: str) -> str:
+        """Resolve a table name to a domain via domain_map globs."""
+        import fnmatch
+
+        for pattern, domain in self.domain_map.items():
+            if fnmatch.fnmatch(table_name, pattern):
+                return domain
+        return self.default_domain
+
+
+@runtime_checkable
+class SourceAdapter(Protocol):
+    """Protocol for source database adapters.
+
+    All methods are async — database I/O is inherently async.
+    Sync wrappers at the client/MCP boundary use asyncio.run().
+    """
+
+    async def connect(self, config: SourceConfig) -> None:
+        """Connect to the source database."""
+        ...
+
+    async def disconnect(self) -> None:
+        """Disconnect from the source database."""
+        ...
+
+    async def discover(self) -> list[TableSchema]:
+        """Discover table schemas from the connected database."""
+        ...
+
+    async def read_rows(
+        self,
+        table: str,
+        batch_size: int = 500,
+        offset: int = 0,
+    ) -> Iterator[dict[str, Any]]:
+        """Read rows from a table in batches."""
+        ...
+
+    async def sync(
+        self,
+        tables: list[str] | None = None,
+        mode: str = "full",
+    ) -> SyncResult:
+        """Sync source data into qortex.
+
+        Args:
+            tables: Tables to sync. None = all discovered tables.
+            mode: "full" = re-sync everything, "incremental" = only changes.
+        """
+        ...

--- a/src/qortex/sources/registry.py
+++ b/src/qortex/sources/registry.py
@@ -1,0 +1,59 @@
+"""SourceRegistry: manages source adapters by source_id.
+
+Holds active adapter connections and their configs. Used by the MCP server
+and client to manage multiple database connections.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from qortex.sources.base import SourceConfig, TableSchema
+
+
+class SourceRegistry:
+    """Registry of active source adapter connections."""
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, Any] = {}  # source_id → SourceAdapter
+        self._configs: dict[str, SourceConfig] = {}
+        self._schemas: dict[str, list[TableSchema]] = {}  # cached discovery
+
+    def register(self, config: SourceConfig, adapter: Any) -> None:
+        """Register an adapter for a source."""
+        self._adapters[config.source_id] = adapter
+        self._configs[config.source_id] = config
+
+    def get(self, source_id: str) -> Any | None:
+        """Get an adapter by source_id."""
+        return self._adapters.get(source_id)
+
+    def get_config(self, source_id: str) -> SourceConfig | None:
+        """Get config by source_id."""
+        return self._configs.get(source_id)
+
+    def remove(self, source_id: str) -> bool:
+        """Remove an adapter. Returns True if it existed."""
+        existed = source_id in self._adapters
+        self._adapters.pop(source_id, None)
+        self._configs.pop(source_id, None)
+        self._schemas.pop(source_id, None)
+        return existed
+
+    def list_sources(self) -> list[str]:
+        """List all registered source IDs."""
+        return list(self._adapters.keys())
+
+    def cache_schemas(self, source_id: str, schemas: list[TableSchema]) -> None:
+        """Cache discovered schemas for a source."""
+        self._schemas[source_id] = schemas
+
+    def get_schemas(self, source_id: str) -> list[TableSchema] | None:
+        """Get cached schemas for a source."""
+        return self._schemas.get(source_id)
+
+    def clear(self) -> None:
+        """Clear all registered adapters."""
+        self._adapters.clear()
+        self._configs.clear()
+        self._schemas.clear()

--- a/src/qortex/sources/serializer.py
+++ b/src/qortex/sources/serializer.py
@@ -1,0 +1,158 @@
+"""Row serializers: convert database rows to text for embedding.
+
+Two strategies:
+- NaturalLanguageSerializer: "A food_item named 'Chicken Breast' with 165 calories..."
+- KeyValueSerializer: "name=Chicken Breast, calories=165, protein=31g"
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Protocol, runtime_checkable
+
+from qortex.sources.base import ColumnSchema, TableSchema
+
+# Columns to skip during serialization (internal/noise)
+_SKIP_PATTERNS = {
+    "id",
+    "uuid",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+    "created_by",
+    "updated_by",
+}
+
+_SKIP_SUFFIXES = ("_id", "_uuid", "_at", "_hash")
+
+# Columns to prioritize (put first in output)
+_PRIORITY_NAMES = {"name", "title", "label", "display_name", "slug"}
+_DESCRIPTION_NAMES = {"description", "notes", "body", "content", "summary", "text"}
+
+
+def _is_internal_column(col_name: str) -> bool:
+    """Check if a column is internal/noise and should be skipped."""
+    lower = col_name.lower()
+    if lower in _SKIP_PATTERNS:
+        return True
+    return any(lower.endswith(s) for s in _SKIP_SUFFIXES)
+
+
+def _humanize_table_name(table_name: str) -> str:
+    """Convert table_name to readable form: food_items → food item."""
+    # Remove trailing 's' for plural
+    name = table_name.rstrip("s") if table_name.endswith("s") and not table_name.endswith("ss") else table_name
+    # Replace underscores with spaces
+    return name.replace("_", " ")
+
+
+def _humanize_column_name(col_name: str) -> str:
+    """Convert column_name to readable form: max_heart_rate → max heart rate."""
+    return col_name.replace("_", " ")
+
+
+def _format_value(value: Any) -> str:
+    """Format a value for serialization."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, float):
+        # Remove trailing zeros
+        return f"{value:g}"
+    if isinstance(value, list):
+        return ", ".join(str(v) for v in value)
+    if isinstance(value, dict):
+        # Flatten one level of nested dict
+        parts = [f"{k}: {v}" for k, v in value.items() if v is not None]
+        return "; ".join(parts)
+    return str(value)
+
+
+@runtime_checkable
+class RowSerializer(Protocol):
+    """Protocol for row serialization strategies."""
+
+    def serialize(self, table_name: str, row: dict[str, Any], schema: TableSchema | None = None) -> str:
+        """Convert a database row to text for embedding."""
+        ...
+
+
+class NaturalLanguageSerializer:
+    """Serialize rows as readable natural language sentences.
+
+    Skips internal columns (id, timestamps, UUIDs).
+    Prioritizes name/title → description/notes → other.
+    """
+
+    def __init__(self, skip_internal: bool = True, max_length: int = 2000) -> None:
+        self.skip_internal = skip_internal
+        self.max_length = max_length
+
+    def serialize(self, table_name: str, row: dict[str, Any], schema: TableSchema | None = None) -> str:
+        """Serialize a row to a natural language sentence."""
+        entity = _humanize_table_name(table_name)
+
+        # Partition columns into priority, description, and other
+        priority_parts: list[str] = []
+        desc_parts: list[str] = []
+        other_parts: list[str] = []
+
+        for col_name, value in row.items():
+            if value is None or value == "":
+                continue
+            if self.skip_internal and _is_internal_column(col_name):
+                continue
+
+            formatted = _format_value(value)
+            if not formatted:
+                continue
+
+            lower = col_name.lower()
+            if lower in _PRIORITY_NAMES:
+                priority_parts.append(f"named '{formatted}'")
+            elif lower in _DESCRIPTION_NAMES:
+                desc_parts.append(formatted)
+            else:
+                readable_col = _humanize_column_name(col_name)
+                other_parts.append(f"{readable_col}: {formatted}")
+
+        # Build sentence
+        parts = []
+        if priority_parts:
+            parts.append(f"A {entity} {' '.join(priority_parts)}")
+        else:
+            parts.append(f"A {entity}")
+
+        if desc_parts:
+            parts.append(". ".join(desc_parts))
+
+        if other_parts:
+            parts.append(f"with {', '.join(other_parts)}")
+
+        result = " ".join(parts)
+        if len(result) > self.max_length:
+            result = result[: self.max_length - 3] + "..."
+        return result
+
+
+class KeyValueSerializer:
+    """Serialize rows as key=value pairs.
+
+    Simple and deterministic. Good for exact matching.
+    """
+
+    def __init__(self, skip_internal: bool = True, separator: str = ", ") -> None:
+        self.skip_internal = skip_internal
+        self.separator = separator
+
+    def serialize(self, table_name: str, row: dict[str, Any], schema: TableSchema | None = None) -> str:
+        """Serialize a row to key=value pairs."""
+        parts = [f"table={table_name}"]
+        for col_name, value in row.items():
+            if value is None:
+                continue
+            if self.skip_internal and _is_internal_column(col_name):
+                continue
+            parts.append(f"{col_name}={_format_value(value)}")
+        return self.separator.join(parts)

--- a/tests/test_sources_base.py
+++ b/tests/test_sources_base.py
@@ -1,0 +1,409 @@
+"""Tests for Layer 2 core: source adapter types, serializers, registry.
+
+No database drivers needed — pure types and serialization logic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from qortex.sources.base import ColumnSchema, SourceConfig, SyncResult, TableSchema
+from qortex.sources.registry import SourceRegistry
+from qortex.sources.serializer import (
+    KeyValueSerializer,
+    NaturalLanguageSerializer,
+    _format_value,
+    _humanize_column_name,
+    _humanize_table_name,
+    _is_internal_column,
+)
+
+
+# ===========================================================================
+# Schema types
+# ===========================================================================
+
+
+class TestColumnSchema:
+    def test_basic_column(self):
+        col = ColumnSchema(name="name", data_type="text")
+        assert col.name == "name"
+        assert col.data_type == "text"
+        assert col.nullable is True
+        assert col.is_pk is False
+        assert col.is_fk is False
+
+    def test_pk_column(self):
+        col = ColumnSchema(name="id", data_type="uuid", is_pk=True, nullable=False)
+        assert col.is_pk is True
+        assert col.nullable is False
+
+    def test_fk_column(self):
+        col = ColumnSchema(
+            name="user_id",
+            data_type="uuid",
+            is_fk=True,
+            foreign_table="users",
+            foreign_column="id",
+        )
+        assert col.is_fk is True
+        assert col.foreign_table == "users"
+        assert col.foreign_column == "id"
+
+
+class TestTableSchema:
+    def test_basic_table(self):
+        cols = [
+            ColumnSchema(name="id", data_type="uuid", is_pk=True),
+            ColumnSchema(name="name", data_type="text"),
+        ]
+        table = TableSchema(name="users", columns=cols, row_count=100)
+        assert table.name == "users"
+        assert table.row_count == 100
+        assert len(table.columns) == 2
+
+    def test_pk_columns(self):
+        cols = [
+            ColumnSchema(name="id", data_type="uuid", is_pk=True),
+            ColumnSchema(name="name", data_type="text"),
+            ColumnSchema(name="version", data_type="integer", is_pk=True),
+        ]
+        table = TableSchema(name="versioned", columns=cols)
+        assert table.pk_columns == ["id", "version"]
+
+    def test_fk_columns(self):
+        cols = [
+            ColumnSchema(name="id", data_type="uuid", is_pk=True),
+            ColumnSchema(name="user_id", data_type="uuid", is_fk=True, foreign_table="users"),
+            ColumnSchema(name="name", data_type="text"),
+        ]
+        table = TableSchema(name="items", columns=cols)
+        assert len(table.fk_columns) == 1
+        assert table.fk_columns[0].name == "user_id"
+
+    def test_full_name(self):
+        table = TableSchema(name="users", schema_name="auth")
+        assert table.full_name == "auth.users"
+
+    def test_default_schema(self):
+        table = TableSchema(name="users")
+        assert table.full_name == "public.users"
+
+
+class TestSyncResult:
+    def test_defaults(self):
+        result = SyncResult(source_id="test")
+        assert result.tables_synced == 0
+        assert result.rows_added == 0
+        assert result.errors == []
+
+    def test_with_data(self):
+        result = SyncResult(
+            source_id="mm",
+            tables_synced=4,
+            rows_added=800,
+            vectors_created=800,
+            duration_seconds=12.5,
+        )
+        assert result.tables_synced == 4
+        assert result.vectors_created == 800
+
+
+# ===========================================================================
+# SourceConfig
+# ===========================================================================
+
+
+class TestSourceConfig:
+    def test_basic_config(self):
+        config = SourceConfig(
+            source_id="mm_movements",
+            connection_string="postgresql://localhost:5435/swae_movements",
+        )
+        assert config.source_id == "mm_movements"
+        assert config.batch_size == 500
+        assert config.default_domain == "default"
+
+    def test_resolve_domain_exact_match(self):
+        config = SourceConfig(
+            source_id="mm",
+            connection_string="postgresql://localhost/mindmirror",
+            domain_map={
+                "habit_*": "habits",
+                "food_*": "nutrition",
+                "journal_*": "journal",
+            },
+        )
+        assert config.resolve_domain("habit_templates") == "habits"
+        assert config.resolve_domain("food_items") == "nutrition"
+        assert config.resolve_domain("journal_entries") == "journal"
+
+    def test_resolve_domain_wildcard(self):
+        config = SourceConfig(
+            source_id="mm",
+            connection_string="postgresql://localhost/mindmirror",
+            domain_map={"*": "catchall"},
+        )
+        assert config.resolve_domain("anything") == "catchall"
+
+    def test_resolve_domain_falls_back_to_default(self):
+        config = SourceConfig(
+            source_id="mm",
+            connection_string="postgresql://localhost/mindmirror",
+            domain_map={"habit_*": "habits"},
+            default_domain="misc",
+        )
+        assert config.resolve_domain("unknown_table") == "misc"
+
+    def test_exclude_tables(self):
+        config = SourceConfig(
+            source_id="mm",
+            connection_string="postgresql://localhost/mindmirror",
+            exclude_tables=["_prisma_migrations", "schema_migrations"],
+        )
+        assert "_prisma_migrations" in config.exclude_tables
+
+
+# ===========================================================================
+# Serializer helpers
+# ===========================================================================
+
+
+class TestSerializerHelpers:
+    def test_is_internal_column(self):
+        assert _is_internal_column("id") is True
+        assert _is_internal_column("uuid") is True
+        assert _is_internal_column("created_at") is True
+        assert _is_internal_column("user_id") is True
+        assert _is_internal_column("name") is False
+        assert _is_internal_column("calories") is False
+        assert _is_internal_column("description") is False
+
+    def test_humanize_table_name(self):
+        assert _humanize_table_name("food_items") == "food item"
+        assert _humanize_table_name("users") == "user"
+        assert _humanize_table_name("address") == "address"
+        assert _humanize_table_name("habit_templates") == "habit template"
+
+    def test_humanize_column_name(self):
+        assert _humanize_column_name("max_heart_rate") == "max heart rate"
+        assert _humanize_column_name("name") == "name"
+
+    def test_format_value_none(self):
+        assert _format_value(None) == ""
+
+    def test_format_value_bool(self):
+        assert _format_value(True) == "yes"
+        assert _format_value(False) == "no"
+
+    def test_format_value_float(self):
+        assert _format_value(3.0) == "3"
+        assert _format_value(3.14) == "3.14"
+
+    def test_format_value_list(self):
+        assert _format_value(["a", "b", "c"]) == "a, b, c"
+
+    def test_format_value_dict(self):
+        result = _format_value({"mood": "happy", "energy": 8})
+        assert "mood: happy" in result
+        assert "energy: 8" in result
+
+
+# ===========================================================================
+# NaturalLanguageSerializer
+# ===========================================================================
+
+
+class TestNaturalLanguageSerializer:
+    def test_simple_row(self):
+        s = NaturalLanguageSerializer()
+        result = s.serialize(
+            "food_items",
+            {"name": "Chicken Breast", "calories": 165, "protein": 31},
+        )
+        assert "food item" in result
+        assert "Chicken Breast" in result
+        assert "calories" in result
+        assert "165" in result
+
+    def test_skips_internal_columns(self):
+        s = NaturalLanguageSerializer()
+        result = s.serialize(
+            "users",
+            {"id": "abc-123", "name": "Alice", "created_at": "2024-01-01"},
+        )
+        assert "abc-123" not in result
+        assert "Alice" in result
+        assert "2024-01-01" not in result
+
+    def test_prioritizes_name(self):
+        s = NaturalLanguageSerializer()
+        result = s.serialize(
+            "movements",
+            {"name": "Deadlift", "muscle_group": "posterior chain", "difficulty": "advanced"},
+        )
+        assert result.startswith("A movement named 'Deadlift'")
+
+    def test_includes_description(self):
+        s = NaturalLanguageSerializer()
+        result = s.serialize(
+            "habits",
+            {"name": "Morning Run", "description": "Run 5km every morning before breakfast"},
+        )
+        assert "Morning Run" in result
+        assert "Run 5km" in result
+
+    def test_mindmirror_food_item(self):
+        """Realistic MindMirror food_items row."""
+        s = NaturalLanguageSerializer()
+        result = s.serialize(
+            "food_items",
+            {
+                "id": "uuid-123",
+                "name": "Salmon Fillet",
+                "calories": 208,
+                "protein": 20.4,
+                "fat": 13.4,
+                "carbs": 0,
+                "serving_size": "100g",
+                "created_at": "2024-01-01",
+            },
+        )
+        assert "food item" in result
+        assert "Salmon Fillet" in result
+        assert "208" in result
+        assert "uuid-123" not in result
+        assert "2024-01-01" not in result
+
+    def test_mindmirror_movement(self):
+        """Realistic MindMirror movement row."""
+        s = NaturalLanguageSerializer()
+        result = s.serialize(
+            "movements",
+            {
+                "id": 42,
+                "name": "Barbell Back Squat",
+                "description": "A compound lower body exercise targeting quads and glutes",
+                "muscle_group": "quadriceps",
+                "equipment": "barbell",
+                "difficulty": "intermediate",
+            },
+        )
+        assert "Barbell Back Squat" in result
+        assert "compound lower body" in result
+        assert "quadriceps" in result
+
+    def test_max_length(self):
+        s = NaturalLanguageSerializer(max_length=50)
+        result = s.serialize(
+            "items",
+            {"name": "X" * 100, "description": "Y" * 100},
+        )
+        assert len(result) <= 50
+
+    def test_none_values_skipped(self):
+        s = NaturalLanguageSerializer()
+        result = s.serialize(
+            "items",
+            {"name": "Test", "optional_field": None, "empty": ""},
+        )
+        assert "optional_field" not in result
+        assert "empty" not in result
+
+    def test_skip_internal_disabled(self):
+        s = NaturalLanguageSerializer(skip_internal=False)
+        result = s.serialize(
+            "items",
+            {"id": "123", "name": "Test", "created_at": "2024-01-01"},
+        )
+        assert "123" in result
+
+
+# ===========================================================================
+# KeyValueSerializer
+# ===========================================================================
+
+
+class TestKeyValueSerializer:
+    def test_simple_row(self):
+        s = KeyValueSerializer()
+        result = s.serialize(
+            "food_items",
+            {"name": "Rice", "calories": 130},
+        )
+        assert "table=food_items" in result
+        assert "name=Rice" in result
+        assert "calories=130" in result
+
+    def test_skips_internal(self):
+        s = KeyValueSerializer()
+        result = s.serialize(
+            "items",
+            {"id": "abc", "name": "Test", "user_id": "xyz"},
+        )
+        assert "id=" not in result
+        assert "user_id=" not in result
+        assert "name=Test" in result
+
+    def test_custom_separator(self):
+        s = KeyValueSerializer(separator=" | ")
+        result = s.serialize("t", {"name": "A", "val": 1})
+        assert " | " in result
+
+
+# ===========================================================================
+# SourceRegistry
+# ===========================================================================
+
+
+class TestSourceRegistry:
+    def test_register_and_get(self):
+        registry = SourceRegistry()
+        config = SourceConfig(source_id="test", connection_string="mock://")
+        adapter = object()
+        registry.register(config, adapter)
+
+        assert registry.get("test") is adapter
+        assert registry.get_config("test") is config
+
+    def test_get_missing_returns_none(self):
+        registry = SourceRegistry()
+        assert registry.get("missing") is None
+        assert registry.get_config("missing") is None
+
+    def test_remove(self):
+        registry = SourceRegistry()
+        config = SourceConfig(source_id="test", connection_string="mock://")
+        registry.register(config, object())
+
+        assert registry.remove("test") is True
+        assert registry.get("test") is None
+        assert registry.remove("test") is False
+
+    def test_list_sources(self):
+        registry = SourceRegistry()
+        registry.register(SourceConfig(source_id="a", connection_string=""), object())
+        registry.register(SourceConfig(source_id="b", connection_string=""), object())
+
+        sources = registry.list_sources()
+        assert set(sources) == {"a", "b"}
+
+    def test_cache_schemas(self):
+        registry = SourceRegistry()
+        config = SourceConfig(source_id="test", connection_string="")
+        registry.register(config, object())
+
+        schemas = [TableSchema(name="users"), TableSchema(name="items")]
+        registry.cache_schemas("test", schemas)
+
+        cached = registry.get_schemas("test")
+        assert cached is not None
+        assert len(cached) == 2
+
+    def test_clear(self):
+        registry = SourceRegistry()
+        registry.register(SourceConfig(source_id="a", connection_string=""), object())
+        registry.register(SourceConfig(source_id="b", connection_string=""), object())
+
+        registry.clear()
+        assert registry.list_sources() == []


### PR DESCRIPTION
## Summary

Partial close of #54 (Layer 2 core types — no database drivers yet)

New `src/qortex/sources/` module with pure types and serialization logic for connecting external databases to qortex:

- `ColumnSchema`, `TableSchema`, `SyncResult`, `SourceConfig` — schema introspection types with domain_map glob matching
- `SourceAdapter` protocol (async): `connect`, `discover`, `read_rows`, `sync`, `disconnect`
- `NaturalLanguageSerializer`: row → readable sentence (skips id/timestamps/UUIDs, prioritizes name/description)
- `KeyValueSerializer`: simple `key=value` pairs
- `SourceRegistry`: manages active adapter connections by source_id with schema caching

## Test plan

- [x] 41 tests in `test_sources_base.py`:
  - Schema types (ColumnSchema, TableSchema, SyncResult)
  - SourceConfig domain_map glob matching and defaults
  - Serializer helpers (_is_internal_column, _humanize_*, _format_value)
  - NaturalLanguageSerializer on MindMirror-shaped rows (food_items, movements)
  - KeyValueSerializer basics
  - SourceRegistry CRUD + schema caching
- [x] Full suite: 1178 passed, 34 skipped, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)