### PR TITLE
feat: wire learning events into structlog and JSONL subscribers

### DIFF
--- a/src/qortex/observability/subscribers/jsonl.py
+++ b/src/qortex/observability/subscribers/jsonl.py
@@ -22,6 +22,9 @@ from qortex.observability.events import (
     InteroceptionShutdown,
     InteroceptionStarted,
     KGCoverageComputed,
+    LearningObservationRecorded,
+    LearningPosteriorUpdated,
+    LearningSelectionMade,
     ManifestIngested,
     OnlineEdgeRecorded,
     OnlineEdgesGenerated,
@@ -60,6 +63,9 @@ _ALL_EVENTS = (
     EnrichmentCompleted,
     EnrichmentFallback,
     ManifestIngested,
+    LearningSelectionMade,
+    LearningObservationRecorded,
+    LearningPosteriorUpdated,
 )
 
 

--- a/src/qortex/observability/subscribers/structlog_sub.py
+++ b/src/qortex/observability/subscribers/structlog_sub.py
@@ -23,6 +23,9 @@ from qortex.observability.events import (
     InteroceptionShutdown,
     InteroceptionStarted,
     KGCoverageComputed,
+    LearningObservationRecorded,
+    LearningPosteriorUpdated,
+    LearningSelectionMade,
     ManifestIngested,
     OnlineEdgeRecorded,
     OnlineEdgesGenerated,
@@ -192,3 +195,23 @@ def _log_enrichment_fallback(event: EnrichmentFallback) -> None:
 @QortexEventLinker.on(ManifestIngested)
 def _log_manifest_ingested(event: ManifestIngested) -> None:
     logger.info("manifest.ingested", **_to_dict(event))
+
+
+# ---------------------------------------------------------------------------
+# Learning
+# ---------------------------------------------------------------------------
+
+
+@QortexEventLinker.on(LearningSelectionMade)
+def _log_learning_selection(event: LearningSelectionMade) -> None:
+    logger.info("learning.selection", **_to_dict(event))
+
+
+@QortexEventLinker.on(LearningObservationRecorded)
+def _log_learning_observation(event: LearningObservationRecorded) -> None:
+    logger.info("learning.observation", **_to_dict(event))
+
+
+@QortexEventLinker.on(LearningPosteriorUpdated)
+def _log_learning_posterior(event: LearningPosteriorUpdated) -> None:
+    logger.debug("learning.posterior", **_to_dict(event))


### PR DESCRIPTION
## Summary
- Wire `LearningSelectionMade`, `LearningObservationRecorded`, `LearningPosteriorUpdated` into structlog and JSONL subscribers
- All 4 observability subscribers (structlog, JSONL, Prometheus, OTEL) now handle learning events consistently
- Fix flaky OTEL protocol config test (`monkeypatch.delenv` for `OTEL_EXPORTER_OTLP_PROTOCOL`)

Closes #77

## Test plan
- [x] `TestStructlogLearningEvents` — 3 tests verify events appear in caplog with correct event names
- [x] `TestJsonlLearningEvents` — verifies events in `_ALL_EVENTS` tuple and written to JSONL file
- [x] OTEL protocol config test no longer depends on env state
- [x] Full suite: 1543 passed, 41 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)