### PR TITLE
feat: centralized feature flags + credit propagation wiring

### DIFF
--- a/src/qortex/flags.py
+++ b/src/qortex/flags.py
@@ -1,0 +1,93 @@
+"""Centralized feature flags: YAML config + env var overrides.
+
+Priority: env var > YAML file > default.
+Env vars use QORTEX_{FLAG_NAME} convention (e.g. QORTEX_TELEPORTATION=on).
+YAML file default: ~/.qortex/flags.yaml
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+
+import yaml
+
+_TRUTHY = {"1", "true", "on", "yes"}
+_DEFAULT_PATH = Path("~/.qortex/flags.yaml").expanduser()
+
+
+@dataclass
+class FeatureFlags:
+    # Core vec store (embedding + similarity) is always on.
+    # Everything below layers on top and can be independently disabled.
+
+    # Graph layer: PPR over knowledge graph (requires a GraphBackend)
+    graph: bool = True
+    # Interoception: teleportation factors + edge promotion buffer
+    teleportation: bool = False
+    online_edges: bool = True
+    # Enrichment: rule extraction from graph neighborhoods
+    enrichment: bool = True
+    # Learning: Thompson Sampling bandit for arm selection
+    learning: bool = True
+    # Causal: DAG construction + d-separation + credit assignment
+    causal: bool = True
+    # Credit propagation: wire CreditAssigner into feedback loop
+    credit_propagation: bool = False
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> FeatureFlags:
+        """Load flags from YAML file, then override with env vars."""
+        file_path = path or _DEFAULT_PATH
+        file_values: dict[str, bool] = {}
+
+        if file_path.exists():
+            raw = yaml.safe_load(file_path.read_text()) or {}
+            if isinstance(raw, dict):
+                for k, v in raw.items():
+                    if isinstance(v, bool):
+                        file_values[k] = v
+                    elif isinstance(v, str):
+                        file_values[k] = v.lower() in _TRUTHY
+
+        # Build kwargs: file values first, then env overrides
+        kwargs: dict[str, bool] = {}
+        for f in fields(cls):
+            name = f.name
+            env_key = f"QORTEX_{name.upper()}"
+
+            if env_key in os.environ:
+                kwargs[name] = os.environ[env_key].lower() in _TRUTHY
+            elif name in file_values:
+                kwargs[name] = file_values[name]
+            # else: use dataclass default
+
+        return cls(**kwargs)
+
+    def to_dict(self) -> dict[str, bool]:
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+    def is_enabled(self, flag_name: str) -> bool:
+        return getattr(self, flag_name, False)
+
+
+# Singleton
+_flags: FeatureFlags | None = None
+_flags_path: Path | None = None
+
+
+def get_flags(path: Path | None = None) -> FeatureFlags:
+    """Get the singleton FeatureFlags instance."""
+    global _flags, _flags_path
+    if _flags is None:
+        _flags_path = path
+        _flags = FeatureFlags.load(path)
+    return _flags
+
+
+def reset_flags() -> None:
+    """Reset for testing."""
+    global _flags, _flags_path
+    _flags = None
+    _flags_path = None

--- a/src/qortex/hippocampus/interoception.py
+++ b/src/qortex/hippocampus/interoception.py
@@ -129,11 +129,10 @@ class InteroceptionProvider(Protocol):
 
 
 def _teleportation_enabled_default() -> bool:
-    """Read QORTEX_TELEPORTATION env var. Default: off (uniform weights)."""
-    import os
+    """Read teleportation flag from centralized FeatureFlags."""
+    from qortex.flags import get_flags
 
-    val = os.environ.get("QORTEX_TELEPORTATION", "off").lower()
-    return val in ("1", "true", "on", "yes")
+    return get_flags().teleportation
 
 
 @dataclass

--- a/src/qortex/mcp/server.py
+++ b/src/qortex/mcp/server.py
@@ -341,6 +341,91 @@ def _query_impl(
 
 _ALLOWED_OUTCOMES = {"accepted", "rejected", "partial"}
 
+_OUTCOME_REWARD = {"accepted": 1.0, "rejected": -1.0, "partial": 0.3}
+
+
+def _maybe_propagate_credit(
+    query_id: str,
+    outcomes: dict[str, str],
+) -> dict | None:
+    """Propagate credit through causal DAG if flag is enabled.
+
+    Returns summary dict or None if disabled/unavailable.
+    """
+    from qortex.flags import get_flags
+
+    if not get_flags().credit_propagation:
+        return None
+
+    try:
+        from qortex.causal.credit import CreditAssigner
+        from qortex.causal.dag import CausalDAG
+    except ImportError:
+        return None
+
+    if not outcomes or _backend is None:
+        return None
+
+    # Group concept IDs by domain
+    domains: dict[str, list[str]] = {}
+    for item_id in outcomes:
+        node = _backend.get_node(item_id)
+        if node is not None:
+            domains.setdefault(node.domain, []).append(item_id)
+
+    if not domains:
+        return None
+
+    all_assignments = []
+    for domain, concept_ids in domains.items():
+        try:
+            dag = CausalDAG.from_backend(_backend, domain)
+        except Exception:
+            continue
+
+        # Compute average reward for this domain's outcomes
+        rewards = [
+            _OUTCOME_REWARD.get(outcomes[cid], 0.0) for cid in concept_ids
+        ]
+        avg_reward = sum(rewards) / len(rewards)
+
+        assigner = CreditAssigner(dag)
+        assignments = assigner.assign_credit(concept_ids, avg_reward)
+        all_assignments.extend(assignments)
+
+    if not all_assignments:
+        return None
+
+    # Convert to posterior updates and apply
+    updates = CreditAssigner.to_posterior_updates(all_assignments)
+    learner = _get_or_create_learner("credit")
+    learner.apply_credit_deltas(updates)
+
+    # Emit event
+    from qortex.observability import emit
+    from qortex.observability.events import CreditPropagated
+
+    direct = sum(1 for a in all_assignments if a.method == "direct")
+    ancestor = sum(1 for a in all_assignments if a.method == "ancestor")
+    total_alpha = sum(u.get("alpha_delta", 0.0) for u in updates.values())
+    total_beta = sum(u.get("beta_delta", 0.0) for u in updates.values())
+
+    emit(CreditPropagated(
+        query_id=query_id,
+        concept_count=len(updates),
+        direct_count=direct,
+        ancestor_count=ancestor,
+        total_alpha_delta=total_alpha,
+        total_beta_delta=total_beta,
+        learner="credit",
+    ))
+
+    return {
+        "concept_count": len(updates),
+        "direct_count": direct,
+        "ancestor_count": ancestor,
+    }
+
 
 def _feedback_impl(
     query_id: str,
@@ -363,12 +448,19 @@ def _feedback_impl(
     elif _adapter is not None:
         _adapter.feedback(query_id, outcomes)
 
-    return {
+    # Credit propagation (if enabled)
+    credit_summary = _maybe_propagate_credit(query_id, outcomes)
+
+    result: dict = {
         "status": "recorded",
         "query_id": query_id,
         "outcome_count": len(outcomes),
         "source": source,
     }
+    if credit_summary is not None:
+        result["credit"] = credit_summary
+
+    return result
 
 
 _ALLOWED_SOURCE_TYPES = {"text", "markdown", "pdf"}

--- a/src/qortex/observability/events.py
+++ b/src/qortex/observability/events.py
@@ -313,3 +313,19 @@ class LearningPosteriorUpdated:
     beta: float
     pulls: int
     mean: float
+
+
+# ---------------------------------------------------------------------------
+# Credit Propagation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CreditPropagated:
+    query_id: str
+    concept_count: int  # concepts that received credit
+    direct_count: int  # method="direct"
+    ancestor_count: int  # method="ancestor"
+    total_alpha_delta: float
+    total_beta_delta: float
+    learner: str

--- a/src/qortex/observability/subscribers/jsonl.py
+++ b/src/qortex/observability/subscribers/jsonl.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from qortex.observability.events import (
     BufferFlushed,
+    CreditPropagated,
     EdgePromoted,
     EnrichmentCompleted,
     EnrichmentFallback,
@@ -66,6 +67,7 @@ _ALL_EVENTS = (
     LearningSelectionMade,
     LearningObservationRecorded,
     LearningPosteriorUpdated,
+    CreditPropagated,
 )
 
 

--- a/src/qortex/observability/subscribers/structlog_sub.py
+++ b/src/qortex/observability/subscribers/structlog_sub.py
@@ -12,6 +12,7 @@ from dataclasses import asdict
 from qortex.observability.logging import get_logger
 from qortex.observability.events import (
     BufferFlushed,
+    CreditPropagated,
     EdgePromoted,
     EnrichmentCompleted,
     EnrichmentFallback,
@@ -215,3 +216,13 @@ def _log_learning_observation(event: LearningObservationRecorded) -> None:
 @QortexEventLinker.on(LearningPosteriorUpdated)
 def _log_learning_posterior(event: LearningPosteriorUpdated) -> None:
     logger.debug("learning.posterior", **_to_dict(event))
+
+
+# ---------------------------------------------------------------------------
+# Credit Propagation
+# ---------------------------------------------------------------------------
+
+
+@QortexEventLinker.on(CreditPropagated)
+def _log_credit_propagated(event: CreditPropagated) -> None:
+    logger.info("credit.propagated", **_to_dict(event))

--- a/tests/test_credit_propagation.py
+++ b/tests/test_credit_propagation.py
@@ -1,0 +1,346 @@
+"""Tests for credit propagation: CreditAssigner → Learner wiring via _maybe_propagate_credit."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qortex.flags import reset_flags
+from qortex.observability import reset as obs_reset
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    obs_reset()
+    reset_flags()
+    yield
+    obs_reset()
+    reset_flags()
+
+
+class TestMaybePropagateCredit:
+    """Unit tests for _maybe_propagate_credit in server.py."""
+
+    def test_returns_none_when_flag_off(self, monkeypatch):
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "off")
+        reset_flags()
+
+        result = _maybe_propagate_credit("q1", {"c:a": "accepted"})
+        assert result is None
+
+    def test_returns_none_when_no_outcomes(self, monkeypatch):
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "on")
+        reset_flags()
+
+        result = _maybe_propagate_credit("q1", {})
+        assert result is None
+
+    def test_returns_none_when_backend_is_none(self, monkeypatch):
+        from qortex.mcp import server
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "on")
+        reset_flags()
+        monkeypatch.setattr(server, "_backend", None)
+
+        result = _maybe_propagate_credit("q1", {"c:a": "accepted"})
+        assert result is None
+
+    def test_returns_none_when_networkx_unavailable(self, monkeypatch):
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "on")
+        reset_flags()
+
+        # Mock backend so we get past the None check
+        mock_backend = MagicMock()
+        mock_backend.get_node.return_value = MagicMock(domain="test")
+
+        import qortex.mcp.server as srv
+        monkeypatch.setattr(srv, "_backend", mock_backend)
+
+        # Simulate networkx not being available
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name in ("qortex.causal.credit", "qortex.causal.dag"):
+                raise ImportError("no networkx")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        result = _maybe_propagate_credit("q1", {"c:a": "accepted"})
+        assert result is None
+
+    def test_returns_none_when_no_nodes_in_backend(self, monkeypatch):
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "on")
+        reset_flags()
+
+        mock_backend = MagicMock()
+        mock_backend.get_node.return_value = None  # concept not found
+
+        import qortex.mcp.server as srv
+        monkeypatch.setattr(srv, "_backend", mock_backend)
+
+        result = _maybe_propagate_credit("q1", {"unknown:x": "accepted"})
+        assert result is None
+
+
+class TestCreditPropagationEndToEnd:
+    """Full end-to-end: backend with DAG → credit → learner update."""
+
+    def test_credit_flows_through_dag(self, monkeypatch, tmp_path):
+        from qortex.causal.dag import CausalDAG
+        from qortex.causal.types import CausalDirection, CausalEdge
+        from qortex.core.models import ConceptNode
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "on")
+        reset_flags()
+
+        # Build a mock backend with known nodes
+        nodes = {
+            "test:a": ConceptNode(id="test:a", name="A", description="", domain="test", source_id="test"),
+            "test:b": ConceptNode(id="test:b", name="B", description="", domain="test", source_id="test"),
+            "test:c": ConceptNode(id="test:c", name="C", description="", domain="test", source_id="test"),
+        }
+
+        mock_backend = MagicMock()
+        mock_backend.get_node.side_effect = lambda nid, **kw: nodes.get(nid)
+
+        # Build a DAG: a → b → c
+        edges = [
+            CausalEdge("test:a", "test:b", "requires", CausalDirection.FORWARD, 0.9),
+            CausalEdge("test:b", "test:c", "requires", CausalDirection.FORWARD, 0.8),
+        ]
+        dag = CausalDAG.from_edges(edges, {n: n for n in nodes})
+
+        import qortex.mcp.server as srv
+        monkeypatch.setattr(srv, "_backend", mock_backend)
+        monkeypatch.setattr(srv, "_learning_state_dir", str(tmp_path))
+        # Clear any cached learners
+        monkeypatch.setattr(srv, "_learners", {})
+
+        # Patch CausalDAG.from_backend to return our test DAG
+        with patch("qortex.causal.dag.CausalDAG.from_backend", return_value=dag):
+            result = _maybe_propagate_credit("q1", {"test:c": "accepted"})
+
+        assert result is not None
+        assert result["direct_count"] >= 1
+        assert result["concept_count"] >= 1
+
+        # Verify learner was updated
+        credit_learner = srv._learners.get("credit")
+        assert credit_learner is not None
+
+        # "test:c" got direct credit, "test:b" is parent, "test:a" is grandparent
+        state_c = credit_learner.store.get("test:c")
+        assert state_c.pulls >= 1
+        assert state_c.alpha > 1.0  # positive credit applied
+
+    def test_rejected_outcome_increases_beta(self, monkeypatch, tmp_path):
+        from qortex.causal.dag import CausalDAG
+        from qortex.causal.types import CausalDirection, CausalEdge, CausalNode
+        from qortex.core.models import ConceptNode
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "on")
+        reset_flags()
+
+        nodes = {
+            "test:x": ConceptNode(id="test:x", name="X", description="", domain="test", source_id="test"),
+            "test:y": ConceptNode(id="test:y", name="Y", description="", domain="test", source_id="test"),
+        }
+        mock_backend = MagicMock()
+        mock_backend.get_node.side_effect = lambda nid, **kw: nodes.get(nid)
+
+        # Two-node DAG so from_edges registers both nodes
+        dag = CausalDAG.from_edges(
+            [CausalEdge("test:y", "test:x", "requires", CausalDirection.FORWARD, 1.0)],
+            {"test:x": "X", "test:y": "Y"},
+        )
+
+        import qortex.mcp.server as srv
+        monkeypatch.setattr(srv, "_backend", mock_backend)
+        monkeypatch.setattr(srv, "_learning_state_dir", str(tmp_path))
+        monkeypatch.setattr(srv, "_learners", {})
+
+        with patch("qortex.causal.dag.CausalDAG.from_backend", return_value=dag):
+            result = _maybe_propagate_credit("q1", {"test:x": "rejected"})
+
+        assert result is not None
+        credit_learner = srv._learners["credit"]
+        state = credit_learner.store.get("test:x")
+        # Rejected → negative reward → beta_delta > 0
+        assert state.beta > 1.0
+
+    def test_partial_outcome_gives_moderate_credit(self, monkeypatch, tmp_path):
+        from qortex.causal.dag import CausalDAG
+        from qortex.causal.types import CausalDirection, CausalEdge
+        from qortex.core.models import ConceptNode
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "on")
+        reset_flags()
+
+        nodes = {
+            "test:p": ConceptNode(id="test:p", name="P", description="", domain="test", source_id="test"),
+            "test:q": ConceptNode(id="test:q", name="Q", description="", domain="test", source_id="test"),
+        }
+        mock_backend = MagicMock()
+        mock_backend.get_node.side_effect = lambda nid, **kw: nodes.get(nid)
+
+        dag = CausalDAG.from_edges(
+            [CausalEdge("test:q", "test:p", "requires", CausalDirection.FORWARD, 1.0)],
+            {"test:p": "P", "test:q": "Q"},
+        )
+
+        import qortex.mcp.server as srv
+        monkeypatch.setattr(srv, "_backend", mock_backend)
+        monkeypatch.setattr(srv, "_learning_state_dir", str(tmp_path))
+        monkeypatch.setattr(srv, "_learners", {})
+
+        with patch("qortex.causal.dag.CausalDAG.from_backend", return_value=dag):
+            result = _maybe_propagate_credit("q1", {"test:p": "partial"})
+
+        assert result is not None
+        credit_learner = srv._learners["credit"]
+        state = credit_learner.store.get("test:p")
+        # Partial → 0.3 reward → moderate alpha boost
+        assert state.alpha > 1.0
+        assert state.alpha < 2.0  # not full credit
+
+    def test_ancestor_credit_decays(self, monkeypatch, tmp_path):
+        from qortex.causal.dag import CausalDAG
+        from qortex.causal.types import CausalDirection, CausalEdge
+        from qortex.core.models import ConceptNode
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "on")
+        reset_flags()
+
+        nodes = {
+            "test:root": ConceptNode(id="test:root", name="Root", description="", domain="test", source_id="test"),
+            "test:mid": ConceptNode(id="test:mid", name="Mid", description="", domain="test", source_id="test"),
+            "test:leaf": ConceptNode(id="test:leaf", name="Leaf", description="", domain="test", source_id="test"),
+        }
+        mock_backend = MagicMock()
+        mock_backend.get_node.side_effect = lambda nid, **kw: nodes.get(nid)
+
+        # root → mid → leaf
+        edges = [
+            CausalEdge("test:root", "test:mid", "requires", CausalDirection.FORWARD, 1.0),
+            CausalEdge("test:mid", "test:leaf", "requires", CausalDirection.FORWARD, 1.0),
+        ]
+        dag = CausalDAG.from_edges(edges, {n: n for n in nodes})
+
+        import qortex.mcp.server as srv
+        monkeypatch.setattr(srv, "_backend", mock_backend)
+        monkeypatch.setattr(srv, "_learning_state_dir", str(tmp_path))
+        monkeypatch.setattr(srv, "_learners", {})
+
+        with patch("qortex.causal.dag.CausalDAG.from_backend", return_value=dag):
+            result = _maybe_propagate_credit("q1", {"test:leaf": "accepted"})
+
+        assert result is not None
+        assert result["ancestor_count"] >= 1
+
+        credit_learner = srv._learners["credit"]
+        leaf_state = credit_learner.store.get("test:leaf")
+        mid_state = credit_learner.store.get("test:mid")
+        root_state = credit_learner.store.get("test:root")
+
+        # Direct > parent > grandparent (decay)
+        leaf_delta = leaf_state.alpha - 1.0
+        mid_delta = mid_state.alpha - 1.0
+        root_delta = root_state.alpha - 1.0
+
+        assert leaf_delta > mid_delta > root_delta > 0
+
+    def test_dag_build_failure_handled_gracefully(self, monkeypatch, tmp_path):
+        from qortex.core.models import ConceptNode
+        from qortex.mcp.server import _maybe_propagate_credit
+
+        monkeypatch.setenv("QORTEX_CREDIT_PROPAGATION", "on")
+        reset_flags()
+
+        nodes = {
+            "test:x": ConceptNode(id="test:x", name="X", description="", domain="test", source_id="test"),
+        }
+        mock_backend = MagicMock()
+        mock_backend.get_node.side_effect = lambda nid, **kw: nodes.get(nid)
+
+        import qortex.mcp.server as srv
+        monkeypatch.setattr(srv, "_backend", mock_backend)
+        monkeypatch.setattr(srv, "_learning_state_dir", str(tmp_path))
+        monkeypatch.setattr(srv, "_learners", {})
+
+        # Make from_backend raise
+        with patch(
+            "qortex.causal.dag.CausalDAG.from_backend",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = _maybe_propagate_credit("q1", {"test:x": "accepted"})
+
+        # Should return None (graceful degradation), not crash
+        assert result is None
+
+
+class TestCreditPropagatedEvent:
+    """Verify CreditPropagated event is emitted and captured."""
+
+    def test_event_in_jsonl_all_events(self):
+        from qortex.observability.events import CreditPropagated
+        from qortex.observability.subscribers.jsonl import _ALL_EVENTS
+
+        assert CreditPropagated in _ALL_EVENTS
+
+    def test_structlog_handler_exists(self):
+        """Verify the structlog handler for CreditPropagated is defined."""
+        from qortex.observability.subscribers.structlog_sub import (
+            _log_credit_propagated,
+        )
+
+        assert callable(_log_credit_propagated)
+
+    def test_event_written_to_jsonl(self, tmp_path):
+        import json
+
+        from qortex.observability.emitter import configure, emit, reset
+        from qortex.observability.events import CreditPropagated
+        from qortex.observability.config import ObservabilityConfig
+
+        reset()
+        cfg = ObservabilityConfig(
+            log_destination="stderr",
+            jsonl_path=str(tmp_path / "events.jsonl"),
+        )
+        configure(cfg)
+
+        emit(CreditPropagated(
+            query_id="q1",
+            concept_count=5,
+            direct_count=2,
+            ancestor_count=3,
+            total_alpha_delta=1.5,
+            total_beta_delta=0.3,
+            learner="credit",
+        ))
+
+        lines = (tmp_path / "events.jsonl").read_text().strip().split("\n")
+        events = [json.loads(line) for line in lines]
+        event_names = [e["event"] for e in events]
+        assert "CreditPropagated" in event_names
+
+        credit_event = next(e for e in events if e["event"] == "CreditPropagated")
+        assert credit_event["concept_count"] == 5
+        assert credit_event["direct_count"] == 2
+        assert credit_event["ancestor_count"] == 3
+        reset()

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,226 @@
+"""Tests for centralized feature flags system."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from qortex.flags import FeatureFlags, get_flags, reset_flags
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    """Reset singleton between tests."""
+    reset_flags()
+    yield
+    reset_flags()
+
+
+class TestFeatureFlagsDefaults:
+    """Default values match expectations."""
+
+    def test_defaults(self):
+        flags = FeatureFlags()
+        assert flags.graph is True
+        assert flags.teleportation is False
+        assert flags.online_edges is True
+        assert flags.enrichment is True
+        assert flags.learning is True
+        assert flags.causal is True
+        assert flags.credit_propagation is False
+
+    def test_to_dict(self):
+        flags = FeatureFlags()
+        d = flags.to_dict()
+        assert isinstance(d, dict)
+        assert d["teleportation"] is False
+        assert d["credit_propagation"] is False
+        assert d["graph"] is True
+
+    def test_is_enabled(self):
+        flags = FeatureFlags(teleportation=True)
+        assert flags.is_enabled("teleportation") is True
+        assert flags.is_enabled("credit_propagation") is False
+        assert flags.is_enabled("nonexistent") is False
+
+
+class TestYAMLLoading:
+    """Load flags from YAML config file."""
+
+    def test_load_from_yaml(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({"teleportation": True, "credit_propagation": True}))
+
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.teleportation is True
+        assert flags.credit_propagation is True
+
+    def test_load_partial_yaml(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({"teleportation": True}))
+
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.teleportation is True
+        assert flags.credit_propagation is False  # default
+
+    def test_load_missing_yaml_uses_defaults(self, tmp_path):
+        flags = FeatureFlags.load(tmp_path / "nonexistent.yaml")
+        assert flags.teleportation is False
+        assert flags.credit_propagation is False
+
+    def test_load_empty_yaml(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text("")
+
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.teleportation is False
+
+    def test_load_non_dict_yaml(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text("just a string")
+
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.teleportation is False
+
+    def test_string_values_in_yaml(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({"teleportation": "on", "credit_propagation": "yes"}))
+
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.teleportation is True
+        assert flags.credit_propagation is True
+
+    def test_unknown_keys_ignored(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({"teleportation": True, "unknown_flag": True}))
+
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.teleportation is True
+
+    def test_disable_graph_layer(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({
+            "graph": False,
+            "enrichment": False,
+            "learning": False,
+            "causal": False,
+            "online_edges": False,
+        }))
+
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.graph is False
+        assert flags.enrichment is False
+        assert flags.learning is False
+        assert flags.causal is False
+        assert flags.online_edges is False
+
+
+class TestEnvVarOverrides:
+    """Env vars override YAML and defaults."""
+
+    def test_env_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("QORTEX_TELEPORTATION", "on")
+        flags = FeatureFlags.load()
+        assert flags.teleportation is True
+
+    def test_env_overrides_yaml(self, monkeypatch, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({"teleportation": False}))
+
+        monkeypatch.setenv("QORTEX_TELEPORTATION", "1")
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.teleportation is True
+
+    def test_env_false_overrides_yaml_true(self, monkeypatch, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({"teleportation": True}))
+
+        monkeypatch.setenv("QORTEX_TELEPORTATION", "off")
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.teleportation is False
+
+    def test_env_truthy_values(self, monkeypatch):
+        for val in ("1", "true", "on", "yes", "True", "ON", "YES"):
+            monkeypatch.setenv("QORTEX_TELEPORTATION", val)
+            flags = FeatureFlags.load()
+            assert flags.teleportation is True, f"Expected True for {val!r}"
+
+    def test_env_falsy_values(self, monkeypatch):
+        for val in ("0", "false", "off", "no", "anything"):
+            monkeypatch.setenv("QORTEX_TELEPORTATION", val)
+            flags = FeatureFlags.load()
+            assert flags.teleportation is False, f"Expected False for {val!r}"
+
+    def test_env_can_disable_defaults(self, monkeypatch):
+        monkeypatch.setenv("QORTEX_GRAPH", "off")
+        monkeypatch.setenv("QORTEX_LEARNING", "off")
+        flags = FeatureFlags.load()
+        assert flags.graph is False
+        assert flags.learning is False
+
+
+class TestPriority:
+    """env var > YAML > default."""
+
+    def test_full_priority_chain(self, monkeypatch, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({
+            "teleportation": True,
+            "credit_propagation": True,
+        }))
+
+        # env overrides yaml for teleportation only
+        monkeypatch.setenv("QORTEX_TELEPORTATION", "off")
+
+        flags = FeatureFlags.load(yaml_file)
+        assert flags.teleportation is False  # env wins over yaml
+        assert flags.credit_propagation is True  # yaml wins over default
+
+
+class TestSingleton:
+    """get_flags() returns cached singleton, reset_flags() clears it."""
+
+    def test_singleton(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({"teleportation": True}))
+
+        f1 = get_flags(yaml_file)
+        f2 = get_flags()
+        assert f1 is f2
+        assert f1.teleportation is True
+
+    def test_reset(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({"teleportation": True}))
+
+        f1 = get_flags(yaml_file)
+        assert f1.teleportation is True
+
+        reset_flags()
+        # After reset, loading without path uses default (no file)
+        f2 = get_flags(tmp_path / "nonexistent.yaml")
+        assert f2 is not f1
+        assert f2.teleportation is False
+
+
+class TestVecOnlyMode:
+    """Everything off except vec store (which has no flag — always on)."""
+
+    def test_vec_only_config(self, tmp_path):
+        yaml_file = tmp_path / "flags.yaml"
+        yaml_file.write_text(yaml.dump({
+            "graph": False,
+            "teleportation": False,
+            "online_edges": False,
+            "enrichment": False,
+            "learning": False,
+            "causal": False,
+            "credit_propagation": False,
+        }))
+
+        flags = FeatureFlags.load(yaml_file)
+        # Everything is off
+        for f_name, val in flags.to_dict().items():
+            assert val is False, f"{f_name} should be False in vec-only mode"

--- a/tests/test_hippocampus.py
+++ b/tests/test_hippocampus.py
@@ -1091,19 +1091,24 @@ class TestLocalInteroceptionProvider:
         assert weights["a"] > weights["b"]
 
     def test_teleportation_env_var(self, monkeypatch):
-        """QORTEX_TELEPORTATION env var controls the default."""
+        """QORTEX_TELEPORTATION env var controls the default via FeatureFlags."""
+        from qortex.flags import reset_flags
         from qortex.hippocampus.interoception import _teleportation_enabled_default
 
         monkeypatch.setenv("QORTEX_TELEPORTATION", "on")
+        reset_flags()
         assert _teleportation_enabled_default() is True
 
         monkeypatch.setenv("QORTEX_TELEPORTATION", "off")
+        reset_flags()
         assert _teleportation_enabled_default() is False
 
         monkeypatch.setenv("QORTEX_TELEPORTATION", "1")
+        reset_flags()
         assert _teleportation_enabled_default() is True
 
         monkeypatch.delenv("QORTEX_TELEPORTATION", raising=False)
+        reset_flags()
         assert _teleportation_enabled_default() is False
 
 


### PR DESCRIPTION
## Summary
- Add `src/qortex/flags.py` — centralized `FeatureFlags` dataclass with YAML config + env var overrides (priority: env > YAML > default)
- 7 flags: `graph`, `teleportation`, `online_edges`, `enrichment`, `learning`, `causal`, `credit_propagation` — subsystems can be toggled independently for vec-only mode
- Wire `_maybe_propagate_credit()` into `_feedback_impl` — CreditAssigner builds CausalDAG per domain, assigns credit, applies deltas to Learner via new `apply_credit_deltas()` method
- Add `CreditPropagated` event to all 4 subscribers (structlog, JSONL, Prometheus, OTEL)
- Migrate `interoception.py` from raw `os.environ.get()` to `get_flags().teleportation`

Closes #74

## Stack
**1 of 3** — merge this first, then #82 (logging fix), then #83 (dashboard)

## Test plan
- [ ] `uv run pytest tests/test_flags.py -v` (21 tests — YAML loading, env override, priority, singleton, vec-only mode)
- [ ] `uv run pytest tests/test_credit_propagation.py -v` (13 tests — flag guards, E2E DAG propagation, event emission)
- [ ] `uv run pytest tests/test_learner.py -v -k credit_deltas` (18 tests — apply_credit_deltas on sqlite + json backends)
- [ ] `uv run pytest tests/test_hippocampus.py -v -k teleportation` (backward compat)
- [ ] Full suite: `uv run pytest --ignore=tests/integration --ignore=tests/test_full_pipeline_e2e.py -x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)