### PR TITLE
fix: stop nuking external log handlers, make structlog logger lazy

### DIFF
--- a/src/qortex/observability/subscribers/structlog_sub.py
+++ b/src/qortex/observability/subscribers/structlog_sub.py
@@ -40,7 +40,9 @@ from qortex.observability.events import (
 )
 from qortex.observability.linker import QortexEventLinker
 
-logger = get_logger("qortex.events")
+def _get_logger():
+    """Lazy logger — always reflects the active formatter, not stale import-time state."""
+    return get_logger("qortex.events")
 
 
 def _to_dict(event: object) -> dict:
@@ -55,17 +57,17 @@ def _to_dict(event: object) -> dict:
 
 @QortexEventLinker.on(QueryStarted)
 def _log_query_started(event: QueryStarted) -> None:
-    logger.info("query.started", **_to_dict(event))
+    _get_logger().info("query.started", **_to_dict(event))
 
 
 @QortexEventLinker.on(QueryCompleted)
 def _log_query_completed(event: QueryCompleted) -> None:
-    logger.info("query.completed", **_to_dict(event))
+    _get_logger().info("query.completed", **_to_dict(event))
 
 
 @QortexEventLinker.on(QueryFailed)
 def _log_query_failed(event: QueryFailed) -> None:
-    logger.error("query.failed", **_to_dict(event))
+    _get_logger().error("query.failed", **_to_dict(event))
 
 
 # ---------------------------------------------------------------------------
@@ -75,17 +77,17 @@ def _log_query_failed(event: QueryFailed) -> None:
 
 @QortexEventLinker.on(PPRStarted)
 def _log_ppr_started(event: PPRStarted) -> None:
-    logger.debug("ppr.started", **_to_dict(event))
+    _get_logger().debug("ppr.started", **_to_dict(event))
 
 
 @QortexEventLinker.on(PPRConverged)
 def _log_ppr_converged(event: PPRConverged) -> None:
-    logger.info("ppr.converged", **_to_dict(event))
+    _get_logger().info("ppr.converged", **_to_dict(event))
 
 
 @QortexEventLinker.on(PPRDiverged)
 def _log_ppr_diverged(event: PPRDiverged) -> None:
-    logger.warning("ppr.diverged", **_to_dict(event))
+    _get_logger().warning("ppr.diverged", **_to_dict(event))
 
 
 # ---------------------------------------------------------------------------
@@ -95,22 +97,22 @@ def _log_ppr_diverged(event: PPRDiverged) -> None:
 
 @QortexEventLinker.on(FactorUpdated)
 def _log_factor_updated(event: FactorUpdated) -> None:
-    logger.debug("factor.updated", **_to_dict(event))
+    _get_logger().debug("factor.updated", **_to_dict(event))
 
 
 @QortexEventLinker.on(FactorsPersisted)
 def _log_factors_persisted(event: FactorsPersisted) -> None:
-    logger.info("factors.persisted", **_to_dict(event))
+    _get_logger().info("factors.persisted", **_to_dict(event))
 
 
 @QortexEventLinker.on(FactorsLoaded)
 def _log_factors_loaded(event: FactorsLoaded) -> None:
-    logger.info("factors.loaded", **_to_dict(event))
+    _get_logger().info("factors.loaded", **_to_dict(event))
 
 
 @QortexEventLinker.on(FactorDriftSnapshot)
 def _log_factor_drift(event: FactorDriftSnapshot) -> None:
-    logger.info("factor.drift", **_to_dict(event))
+    _get_logger().info("factor.drift", **_to_dict(event))
 
 
 # ---------------------------------------------------------------------------
@@ -120,17 +122,17 @@ def _log_factor_drift(event: FactorDriftSnapshot) -> None:
 
 @QortexEventLinker.on(OnlineEdgeRecorded)
 def _log_online_edge(event: OnlineEdgeRecorded) -> None:
-    logger.debug("edge.recorded", **_to_dict(event))
+    _get_logger().debug("edge.recorded", **_to_dict(event))
 
 
 @QortexEventLinker.on(EdgePromoted)
 def _log_edge_promoted(event: EdgePromoted) -> None:
-    logger.info("edge.promoted", **_to_dict(event))
+    _get_logger().info("edge.promoted", **_to_dict(event))
 
 
 @QortexEventLinker.on(BufferFlushed)
 def _log_buffer_flushed(event: BufferFlushed) -> None:
-    logger.info("buffer.flushed", **_to_dict(event))
+    _get_logger().info("buffer.flushed", **_to_dict(event))
 
 
 # ---------------------------------------------------------------------------
@@ -140,22 +142,22 @@ def _log_buffer_flushed(event: BufferFlushed) -> None:
 
 @QortexEventLinker.on(VecSearchCompleted)
 def _log_vec_search(event: VecSearchCompleted) -> None:
-    logger.debug("vec.search.completed", **_to_dict(event))
+    _get_logger().debug("vec.search.completed", **_to_dict(event))
 
 
 @QortexEventLinker.on(OnlineEdgesGenerated)
 def _log_online_edges(event: OnlineEdgesGenerated) -> None:
-    logger.debug("online.edges.generated", **_to_dict(event))
+    _get_logger().debug("online.edges.generated", **_to_dict(event))
 
 
 @QortexEventLinker.on(KGCoverageComputed)
 def _log_kg_coverage(event: KGCoverageComputed) -> None:
-    logger.info("kg.coverage", **_to_dict(event))
+    _get_logger().info("kg.coverage", **_to_dict(event))
 
 
 @QortexEventLinker.on(FeedbackReceived)
 def _log_feedback(event: FeedbackReceived) -> None:
-    logger.info("feedback.received", **_to_dict(event))
+    _get_logger().info("feedback.received", **_to_dict(event))
 
 
 # ---------------------------------------------------------------------------
@@ -165,12 +167,12 @@ def _log_feedback(event: FeedbackReceived) -> None:
 
 @QortexEventLinker.on(InteroceptionStarted)
 def _log_interoception_started(event: InteroceptionStarted) -> None:
-    logger.info("interoception.started", **_to_dict(event))
+    _get_logger().info("interoception.started", **_to_dict(event))
 
 
 @QortexEventLinker.on(InteroceptionShutdown)
 def _log_interoception_shutdown(event: InteroceptionShutdown) -> None:
-    logger.info("interoception.shutdown", **_to_dict(event))
+    _get_logger().info("interoception.shutdown", **_to_dict(event))
 
 
 # ---------------------------------------------------------------------------
@@ -180,12 +182,12 @@ def _log_interoception_shutdown(event: InteroceptionShutdown) -> None:
 
 @QortexEventLinker.on(EnrichmentCompleted)
 def _log_enrichment_completed(event: EnrichmentCompleted) -> None:
-    logger.info("enrichment.completed", **_to_dict(event))
+    _get_logger().info("enrichment.completed", **_to_dict(event))
 
 
 @QortexEventLinker.on(EnrichmentFallback)
 def _log_enrichment_fallback(event: EnrichmentFallback) -> None:
-    logger.warning("enrichment.fallback", **_to_dict(event))
+    _get_logger().warning("enrichment.fallback", **_to_dict(event))
 
 
 # ---------------------------------------------------------------------------
@@ -195,7 +197,7 @@ def _log_enrichment_fallback(event: EnrichmentFallback) -> None:
 
 @QortexEventLinker.on(ManifestIngested)
 def _log_manifest_ingested(event: ManifestIngested) -> None:
-    logger.info("manifest.ingested", **_to_dict(event))
+    _get_logger().info("manifest.ingested", **_to_dict(event))
 
 
 # ---------------------------------------------------------------------------
@@ -205,17 +207,17 @@ def _log_manifest_ingested(event: ManifestIngested) -> None:
 
 @QortexEventLinker.on(LearningSelectionMade)
 def _log_learning_selection(event: LearningSelectionMade) -> None:
-    logger.info("learning.selection", **_to_dict(event))
+    _get_logger().info("learning.selection", **_to_dict(event))
 
 
 @QortexEventLinker.on(LearningObservationRecorded)
 def _log_learning_observation(event: LearningObservationRecorded) -> None:
-    logger.info("learning.observation", **_to_dict(event))
+    _get_logger().info("learning.observation", **_to_dict(event))
 
 
 @QortexEventLinker.on(LearningPosteriorUpdated)
 def _log_learning_posterior(event: LearningPosteriorUpdated) -> None:
-    logger.debug("learning.posterior", **_to_dict(event))
+    _get_logger().debug("learning.posterior", **_to_dict(event))
 
 
 # ---------------------------------------------------------------------------
@@ -225,4 +227,4 @@ def _log_learning_posterior(event: LearningPosteriorUpdated) -> None:
 
 @QortexEventLinker.on(CreditPropagated)
 def _log_credit_propagated(event: CreditPropagated) -> None:
-    logger.info("credit.propagated", **_to_dict(event))
+    _get_logger().info("credit.propagated", **_to_dict(event))


### PR DESCRIPTION
## Summary
- Fix `setup_logging()` — was calling `root_logger.handlers.clear()` which destroyed ALL handlers (monitoring agents, pytest caplog, log aggregation). Now tags our handler with `_qortex_managed` and only removes those on reconfigure.
- Fix stale module-level logger in `structlog_sub.py` — was `logger = get_logger()` at import time, never updated when formatter changed. Now uses `_get_logger()` function for lazy resolution on each call.
- Upgrade credit propagation structlog test from existence check to `caplog` assertion (works correctly now that `configure()` preserves external handlers)
- Add Prometheus counter tests for `credit_alpha_delta_total` / `credit_beta_delta_total`

## Stack
**2 of 3** — merge after #81 (flags + credit wiring)

## Test plan
- [ ] `uv run pytest tests/test_credit_propagation.py::TestCreditPropagatedEvent -v` (caplog test passes without capfd hack)
- [ ] `uv run pytest tests/test_observability.py -v -k credit` (new prometheus counter tests)
- [ ] `uv run pytest tests/test_observability.py::TestStructlogLearningEvents -v` (existing caplog tests still pass)
- [ ] Full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)