### PR TITLE
feat: async learning store (sqlite3 → aiosqlite)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "numpy>=1.24",
     "pyventus>=0.7",
     "structlog>=24.0",
+    "aiosqlite>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_e2e_mastra.py
+++ b/tests/test_e2e_mastra.py
@@ -311,7 +311,7 @@ class TestMastraFeedbackUpgrade:
     A Mastra TS client using qortex gets this for free via MCP.
     """
 
-    def test_full_query_feedback_cycle(self, mcp_server, ingested_domain):
+    async def test_full_query_feedback_cycle(self, mcp_server, ingested_domain):
         from qortex.mcp.server import _feedback_impl, _query_impl
 
         # 1. Query (same as Mastra would)
@@ -324,7 +324,7 @@ class TestMastraFeedbackUpgrade:
         query_id = query_result["query_id"]
 
         # 2. Feedback (Mastra can't do this)
-        feedback_result = _feedback_impl(
+        feedback_result = await _feedback_impl(
             query_id=query_id,
             outcomes={
                 query_result["items"][0]["id"]: "accepted",
@@ -357,7 +357,7 @@ class TestMastraE2ESimulation:
     code paths that JSON-RPC tool calls hit.
     """
 
-    def test_full_consumer_workflow(self, mcp_server, ingested_domain):
+    async def test_full_consumer_workflow(self, mcp_server, ingested_domain):
         from qortex.mcp.server import (
             _domains_impl,
             _embedding_model,
@@ -422,7 +422,7 @@ class TestMastraE2ESimulation:
         )
 
         # --- Step 5: feedback() (the upgrade Mastra doesn't have) ---
-        fb = _feedback_impl(
+        fb = await _feedback_impl(
             query_id=raw["query_id"],
             outcomes={mastra_results[0]["id"]: "accepted"},
             source="mastra-e2e",
@@ -438,7 +438,7 @@ class TestMastraE2ESimulation:
         assert len(raw2["items"]) > 0
         assert raw2["query_id"] != raw["query_id"]  # different query IDs
 
-    def test_json_serializable(self, mcp_server, ingested_domain):
+    async def test_json_serializable(self, mcp_server, ingested_domain):
         """Every MCP response must be JSON-serializable (goes over stdio)."""
         from qortex.mcp.server import (
             _domains_impl,
@@ -458,7 +458,7 @@ class TestMastraE2ESimulation:
         assert json.loads(json.dumps(query)) == query
 
         if query["items"]:
-            fb = _feedback_impl(query["query_id"], {query["items"][0]["id"]: "accepted"})
+            fb = await _feedback_impl(query["query_id"], {query["items"][0]["id"]: "accepted"})
             assert json.loads(json.dumps(fb)) == fb
 
 

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -40,29 +40,29 @@ def config(state_dir):
 
 
 @pytest.fixture
-def learner(config, store_backend):
-    return Learner(config, store=store_backend(config.name))
+async def learner(config, store_backend):
+    return await Learner.create(config, store=store_backend(config.name))
 
 
 class TestLearnerSelect:
-    def test_select_returns_arms(self, learner):
+    async def test_select_returns_arms(self, learner):
         candidates = [Arm(id="a"), Arm(id="b"), Arm(id="c")]
-        result = learner.select(candidates, k=2)
+        result = await learner.select(candidates, k=2)
 
         assert len(result.selected) == 2
         assert len(result.excluded) == 1
         assert not result.is_baseline
 
-    def test_select_with_context(self, learner):
+    async def test_select_with_context(self, learner):
         candidates = [Arm(id="a"), Arm(id="b")]
-        result = learner.select(candidates, context={"task": "testing"}, k=1)
+        result = await learner.select(candidates, context={"task": "testing"}, k=1)
 
         assert len(result.selected) == 1
 
 
 class TestLearnerObserve:
-    def test_observe_updates_posterior(self, learner):
-        state = learner.observe(
+    async def test_observe_updates_posterior(self, learner):
+        state = await learner.observe(
             ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted")
         )
 
@@ -70,9 +70,9 @@ class TestLearnerObserve:
         assert state.beta == 1.0
         assert state.pulls == 1
 
-    def test_observe_uses_reward_model(self, learner):
+    async def test_observe_uses_reward_model(self, learner):
         # TernaryReward: "partial" → 0.5
-        state = learner.observe(
+        state = await learner.observe(
             ArmOutcome(arm_id="arm:b", reward=0.0, outcome="partial")
         )
 
@@ -80,18 +80,18 @@ class TestLearnerObserve:
         assert state.beta == 1.5
         assert state.pulls == 1
 
-    def test_observe_rejected(self, learner):
-        state = learner.observe(
+    async def test_observe_rejected(self, learner):
+        state = await learner.observe(
             ArmOutcome(arm_id="arm:c", reward=0.0, outcome="rejected")
         )
 
         assert state.alpha == 1.0
         assert state.beta == 2.0
 
-    def test_observe_multiple(self, learner):
-        learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
-        learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
-        state = learner.observe(
+    async def test_observe_multiple(self, learner):
+        await learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
+        await learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
+        state = await learner.observe(
             ArmOutcome(arm_id="arm:a", reward=0.0, outcome="rejected")
         )
 
@@ -101,82 +101,82 @@ class TestLearnerObserve:
 
 
 class TestLearnerPersistence:
-    def test_state_persists_to_file(self, config, state_dir, store_backend):
-        learner = Learner(config, store=store_backend(config.name))
-        learner.observe(ArmOutcome(arm_id="arm:x", reward=1.0, outcome="accepted"))
+    async def test_state_persists_to_file(self, config, state_dir, store_backend):
+        learner = await Learner.create(config, store=store_backend(config.name))
+        await learner.observe(ArmOutcome(arm_id="arm:x", reward=1.0, outcome="accepted"))
 
         # Verify state is readable via store
-        state = learner.store.get("arm:x")
+        state = await learner.store.get("arm:x")
         assert state.alpha == 2.0
 
-    def test_state_reloaded_on_new_learner(self, config, state_dir, store_backend):
-        learner1 = Learner(config, store=store_backend(config.name))
-        learner1.observe(ArmOutcome(arm_id="arm:y", reward=1.0, outcome="accepted"))
+    async def test_state_reloaded_on_new_learner(self, config, state_dir, store_backend):
+        learner1 = await Learner.create(config, store=store_backend(config.name))
+        await learner1.observe(ArmOutcome(arm_id="arm:y", reward=1.0, outcome="accepted"))
 
         # Create new learner with same backend — should reload state
-        learner2 = Learner(config, store=store_backend(config.name))
-        posteriors = learner2.posteriors()
+        learner2 = await Learner.create(config, store=store_backend(config.name))
+        posteriors = await learner2.posteriors()
 
         assert "arm:y" in posteriors
         assert posteriors["arm:y"]["alpha"] == 2.0
 
 
 class TestLearnerPosteriors:
-    def test_posteriors_empty(self, learner):
-        p = learner.posteriors()
+    async def test_posteriors_empty(self, learner):
+        p = await learner.posteriors()
         assert p == {}
 
-    def test_posteriors_after_observe(self, learner):
-        learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
-        learner.observe(ArmOutcome(arm_id="arm:b", reward=0.0, outcome="rejected"))
+    async def test_posteriors_after_observe(self, learner):
+        await learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
+        await learner.observe(ArmOutcome(arm_id="arm:b", reward=0.0, outcome="rejected"))
 
-        p = learner.posteriors()
+        p = await learner.posteriors()
         assert "arm:a" in p
         assert "arm:b" in p
         assert p["arm:a"]["mean"] > p["arm:b"]["mean"]
 
-    def test_posteriors_filter_by_arm_ids(self, learner):
-        learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
-        learner.observe(ArmOutcome(arm_id="arm:b", reward=0.0, outcome="rejected"))
+    async def test_posteriors_filter_by_arm_ids(self, learner):
+        await learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
+        await learner.observe(ArmOutcome(arm_id="arm:b", reward=0.0, outcome="rejected"))
 
-        p = learner.posteriors(arm_ids=["arm:a"])
+        p = await learner.posteriors(arm_ids=["arm:a"])
         assert "arm:a" in p
         assert "arm:b" not in p
 
 
 class TestLearnerMetrics:
-    def test_metrics_empty(self, learner):
-        m = learner.metrics()
+    async def test_metrics_empty(self, learner):
+        m = await learner.metrics()
         assert m["total_pulls"] == 0
         assert m["accuracy"] == 0.0
 
-    def test_metrics_after_observations(self, learner):
-        learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
-        learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
-        learner.observe(ArmOutcome(arm_id="arm:a", reward=0.0, outcome="rejected"))
+    async def test_metrics_after_observations(self, learner):
+        await learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
+        await learner.observe(ArmOutcome(arm_id="arm:a", reward=1.0, outcome="accepted"))
+        await learner.observe(ArmOutcome(arm_id="arm:a", reward=0.0, outcome="rejected"))
 
-        m = learner.metrics()
+        m = await learner.metrics()
         assert m["total_pulls"] == 3
         assert m["total_reward"] == 2.0
 
 
 class TestLearnerSeedBoost:
-    def test_seed_arms_get_boosted_prior(self, state_dir, store_backend):
+    async def test_seed_arms_get_boosted_prior(self, state_dir, store_backend):
         config = LearnerConfig(
             name="seed-test",
             seed_arms=["arm:seed"],
             seed_boost=5.0,
             state_dir=state_dir,
         )
-        learner = Learner(config, store=store_backend("seed-test"))
+        learner = await Learner.create(config, store=store_backend("seed-test"))
 
-        p = learner.posteriors()
+        p = await learner.posteriors()
         assert "arm:seed" in p
         assert p["arm:seed"]["alpha"] == 5.0
 
 
 class TestLearnerSessions:
-    def test_session_lifecycle(self, learner):
+    async def test_session_lifecycle(self, learner):
         sid = learner.session_start("test-session")
         assert sid
 
@@ -185,27 +185,27 @@ class TestLearnerSessions:
         assert summary["started_at"]
         assert summary["ended_at"]
 
-    def test_session_not_found(self, learner):
+    async def test_session_not_found(self, learner):
         result = learner.session_end("nonexistent")
         assert "error" in result
 
 
 class TestContextPartitioning:
-    def test_different_contexts_independent(self, learner):
+    async def test_different_contexts_independent(self, learner):
         ctx_a = {"task": "typing"}
         ctx_b = {"task": "linting"}
 
-        learner.observe(
+        await learner.observe(
             ArmOutcome(arm_id="arm:x", reward=1.0, outcome="accepted"),
             context=ctx_a,
         )
-        learner.observe(
+        await learner.observe(
             ArmOutcome(arm_id="arm:x", reward=0.0, outcome="rejected"),
             context=ctx_b,
         )
 
-        p_a = learner.posteriors(context=ctx_a)
-        p_b = learner.posteriors(context=ctx_b)
+        p_a = await learner.posteriors(context=ctx_a)
+        p_b = await learner.posteriors(context=ctx_b)
 
         assert p_a["arm:x"]["alpha"] == 2.0  # 1 + 1.0 reward
         assert p_b["arm:x"]["alpha"] == 1.0  # 1 + 0.0 reward
@@ -214,74 +214,74 @@ class TestContextPartitioning:
 class TestApplyCreditDeltas:
     """Tests for Learner.apply_credit_deltas() — causal credit integration."""
 
-    def test_basic_delta_application(self, learner):
+    async def test_basic_delta_application(self, learner):
         deltas = {
             "concept:a": {"alpha_delta": 0.5, "beta_delta": 0.0},
             "concept:b": {"alpha_delta": 0.0, "beta_delta": 0.3},
         }
-        results = learner.apply_credit_deltas(deltas)
+        results = await learner.apply_credit_deltas(deltas)
 
         assert results["concept:a"].alpha == pytest.approx(1.5)  # 1.0 + 0.5
         assert results["concept:a"].beta == pytest.approx(1.0)
         assert results["concept:b"].alpha == pytest.approx(1.0)
         assert results["concept:b"].beta == pytest.approx(1.3)  # 1.0 + 0.3
 
-    def test_pulls_incremented(self, learner):
+    async def test_pulls_incremented(self, learner):
         deltas = {"arm:x": {"alpha_delta": 0.5, "beta_delta": 0.0}}
-        results = learner.apply_credit_deltas(deltas)
+        results = await learner.apply_credit_deltas(deltas)
         assert results["arm:x"].pulls == 1
 
         # Apply again
-        results = learner.apply_credit_deltas(deltas)
+        results = await learner.apply_credit_deltas(deltas)
         assert results["arm:x"].pulls == 2
 
-    def test_total_reward_tracks_alpha_delta(self, learner):
+    async def test_total_reward_tracks_alpha_delta(self, learner):
         deltas = {"arm:x": {"alpha_delta": 0.7, "beta_delta": 0.1}}
-        results = learner.apply_credit_deltas(deltas)
+        results = await learner.apply_credit_deltas(deltas)
         assert results["arm:x"].total_reward == pytest.approx(0.7)
 
-    def test_alpha_beta_floored_at_001(self, learner):
+    async def test_alpha_beta_floored_at_001(self, learner):
         """Negative deltas can't take alpha/beta below 0.01."""
         deltas = {"arm:x": {"alpha_delta": -5.0, "beta_delta": -5.0}}
-        results = learner.apply_credit_deltas(deltas)
+        results = await learner.apply_credit_deltas(deltas)
         assert results["arm:x"].alpha == pytest.approx(0.01)
         assert results["arm:x"].beta == pytest.approx(0.01)
 
-    def test_empty_deltas(self, learner):
-        results = learner.apply_credit_deltas({})
+    async def test_empty_deltas(self, learner):
+        results = await learner.apply_credit_deltas({})
         assert results == {}
 
-    def test_persisted_to_store(self, learner):
+    async def test_persisted_to_store(self, learner):
         deltas = {"arm:x": {"alpha_delta": 0.5, "beta_delta": 0.0}}
-        learner.apply_credit_deltas(deltas)
+        await learner.apply_credit_deltas(deltas)
 
         # Read back from store
-        state = learner.store.get("arm:x")
+        state = await learner.store.get("arm:x")
         assert state.alpha == pytest.approx(1.5)
         assert state.pulls == 1
 
-    def test_with_context(self, learner):
+    async def test_with_context(self, learner):
         ctx = {"task": "test"}
         deltas = {"arm:x": {"alpha_delta": 1.0, "beta_delta": 0.0}}
-        learner.apply_credit_deltas(deltas, context=ctx)
+        await learner.apply_credit_deltas(deltas, context=ctx)
 
         # Different context should be unaffected
-        state_default = learner.store.get("arm:x")
-        state_ctx = learner.store.get("arm:x", ctx)
+        state_default = await learner.store.get("arm:x")
+        state_ctx = await learner.store.get("arm:x", ctx)
         assert state_default.alpha == pytest.approx(1.0)  # untouched
         assert state_ctx.alpha == pytest.approx(2.0)
 
-    def test_multiple_concepts(self, learner):
+    async def test_multiple_concepts(self, learner):
         deltas = {
             f"concept:{i}": {"alpha_delta": 0.1 * i, "beta_delta": 0.0}
             for i in range(1, 6)
         }
-        results = learner.apply_credit_deltas(deltas)
+        results = await learner.apply_credit_deltas(deltas)
         assert len(results) == 5
         assert results["concept:3"].alpha == pytest.approx(1.3)
 
-    def test_missing_delta_keys_default_to_zero(self, learner):
+    async def test_missing_delta_keys_default_to_zero(self, learner):
         deltas = {"arm:x": {"alpha_delta": 0.5}}  # no beta_delta
-        results = learner.apply_credit_deltas(deltas)
+        results = await learner.apply_credit_deltas(deltas)
         assert results["arm:x"].alpha == pytest.approx(1.5)
         assert results["arm:x"].beta == pytest.approx(1.0)  # unchanged

--- a/tests/test_learning_store.py
+++ b/tests/test_learning_store.py
@@ -45,51 +45,51 @@ class TestProtocolCompliance:
 
 
 class TestStoreCRUD:
-    def test_get_missing_returns_default(self, store):
-        state = store.get("nonexistent")
+    async def test_get_missing_returns_default(self, store):
+        state = await store.get("nonexistent")
         assert state.alpha == 1.0
         assert state.beta == 1.0
         assert state.pulls == 0
 
-    def test_put_then_get(self, store):
+    async def test_put_then_get(self, store):
         s = ArmState(alpha=3.0, beta=2.0, pulls=5, total_reward=3.0, last_updated="t1")
-        store.put("arm:a", s)
-        got = store.get("arm:a")
+        await store.put("arm:a", s)
+        got = await store.get("arm:a")
         assert got.alpha == 3.0
         assert got.beta == 2.0
         assert got.pulls == 5
         assert got.total_reward == 3.0
         assert got.last_updated == "t1"
 
-    def test_put_overwrites(self, store):
-        store.put("arm:a", ArmState(alpha=2.0))
-        store.put("arm:a", ArmState(alpha=9.0))
-        assert store.get("arm:a").alpha == 9.0
+    async def test_put_overwrites(self, store):
+        await store.put("arm:a", ArmState(alpha=2.0))
+        await store.put("arm:a", ArmState(alpha=9.0))
+        assert (await store.get("arm:a")).alpha == 9.0
 
-    def test_get_all_empty(self, store):
-        assert store.get_all() == {}
+    async def test_get_all_empty(self, store):
+        assert await store.get_all() == {}
 
-    def test_get_all_returns_context_arms(self, store):
-        store.put("arm:a", ArmState(alpha=2.0))
-        store.put("arm:b", ArmState(alpha=3.0))
-        all_arms = store.get_all()
+    async def test_get_all_returns_context_arms(self, store):
+        await store.put("arm:a", ArmState(alpha=2.0))
+        await store.put("arm:b", ArmState(alpha=3.0))
+        all_arms = await store.get_all()
         assert set(all_arms.keys()) == {"arm:a", "arm:b"}
         assert all_arms["arm:a"].alpha == 2.0
 
-    def test_get_all_contexts_empty(self, store):
-        assert store.get_all_contexts() == []
+    async def test_get_all_contexts_empty(self, store):
+        assert await store.get_all_contexts() == []
 
-    def test_get_all_contexts(self, store):
-        store.put("arm:a", ArmState(), context={"task": "x"})
-        store.put("arm:b", ArmState(), context={"task": "y"})
-        contexts = store.get_all_contexts()
+    async def test_get_all_contexts(self, store):
+        await store.put("arm:a", ArmState(), context={"task": "x"})
+        await store.put("arm:b", ArmState(), context={"task": "y"})
+        contexts = await store.get_all_contexts()
         assert len(contexts) == 2
 
-    def test_save_persists_data(self, store):
-        store.put("arm:a", ArmState(alpha=5.0))
-        store.save()
+    async def test_save_persists_data(self, store):
+        await store.put("arm:a", ArmState(alpha=5.0))
+        await store.save()
         # Verify data is still readable after explicit save
-        assert store.get("arm:a").alpha == 5.0
+        assert (await store.get("arm:a")).alpha == 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -98,33 +98,33 @@ class TestStoreCRUD:
 
 
 class TestContextPartitioning:
-    def test_same_arm_different_contexts_independent(self, store):
+    async def test_same_arm_different_contexts_independent(self, store):
         ctx_a = {"task": "typing"}
         ctx_b = {"task": "linting"}
 
-        store.put("arm:x", ArmState(alpha=10.0), context=ctx_a)
-        store.put("arm:x", ArmState(alpha=1.0), context=ctx_b)
+        await store.put("arm:x", ArmState(alpha=10.0), context=ctx_a)
+        await store.put("arm:x", ArmState(alpha=1.0), context=ctx_b)
 
-        assert store.get("arm:x", context=ctx_a).alpha == 10.0
-        assert store.get("arm:x", context=ctx_b).alpha == 1.0
+        assert (await store.get("arm:x", context=ctx_a)).alpha == 10.0
+        assert (await store.get("arm:x", context=ctx_b)).alpha == 1.0
 
-    def test_get_all_scoped_to_context(self, store):
+    async def test_get_all_scoped_to_context(self, store):
         ctx_a = {"task": "typing"}
         ctx_b = {"task": "linting"}
 
-        store.put("arm:a", ArmState(alpha=2.0), context=ctx_a)
-        store.put("arm:b", ArmState(alpha=3.0), context=ctx_b)
+        await store.put("arm:a", ArmState(alpha=2.0), context=ctx_a)
+        await store.put("arm:b", ArmState(alpha=3.0), context=ctx_b)
 
-        a_arms = store.get_all(context=ctx_a)
+        a_arms = await store.get_all(context=ctx_a)
         assert "arm:a" in a_arms
         assert "arm:b" not in a_arms
 
-    def test_default_context_is_none(self, store):
-        store.put("arm:a", ArmState(alpha=5.0))
-        store.put("arm:a", ArmState(alpha=9.0), context={"task": "x"})
+    async def test_default_context_is_none(self, store):
+        await store.put("arm:a", ArmState(alpha=5.0))
+        await store.put("arm:a", ArmState(alpha=9.0), context={"task": "x"})
 
-        assert store.get("arm:a").alpha == 5.0
-        assert store.get("arm:a", context={"task": "x"}).alpha == 9.0
+        assert (await store.get("arm:a")).alpha == 5.0
+        assert (await store.get("arm:a", context={"task": "x"})).alpha == 9.0
 
 
 # ---------------------------------------------------------------------------
@@ -133,14 +133,14 @@ class TestContextPartitioning:
 
 
 class TestGetAllStates:
-    def test_empty(self, store):
-        assert store.get_all_states() == {}
+    async def test_empty(self, store):
+        assert await store.get_all_states() == {}
 
-    def test_returns_nested_dict(self, store):
-        store.put("arm:a", ArmState(alpha=2.0))
-        store.put("arm:b", ArmState(alpha=3.0), context={"task": "x"})
+    async def test_returns_nested_dict(self, store):
+        await store.put("arm:a", ArmState(alpha=2.0))
+        await store.put("arm:b", ArmState(alpha=3.0), context={"task": "x"})
 
-        all_states = store.get_all_states()
+        all_states = await store.get_all_states()
         assert len(all_states) == 2
 
         # Find keys (context hashes)
@@ -149,11 +149,11 @@ class TestGetAllStates:
             for arm_id, state in arms.items():
                 assert isinstance(state, ArmState)
 
-    def test_all_states_has_correct_values(self, store):
-        store.put("arm:a", ArmState(alpha=2.0, pulls=3, total_reward=2.0))
-        store.put("arm:b", ArmState(alpha=4.0, pulls=5, total_reward=4.0))
+    async def test_all_states_has_correct_values(self, store):
+        await store.put("arm:a", ArmState(alpha=2.0, pulls=3, total_reward=2.0))
+        await store.put("arm:b", ArmState(alpha=4.0, pulls=5, total_reward=4.0))
 
-        all_states = store.get_all_states()
+        all_states = await store.get_all_states()
         # Both arms in default context
         default_ctx = list(all_states.values())[0]
         assert default_ctx["arm:a"].alpha == 2.0
@@ -166,38 +166,38 @@ class TestGetAllStates:
 
 
 class TestSqlitePersistence:
-    def test_data_survives_new_instance(self, state_dir):
+    async def test_data_survives_new_instance(self, state_dir):
         store1 = SqliteLearningStore("persist-test", state_dir)
-        store1.put("arm:a", ArmState(alpha=7.0, beta=2.0, pulls=10, total_reward=7.0))
-        store1.save()
+        await store1.put("arm:a", ArmState(alpha=7.0, beta=2.0, pulls=10, total_reward=7.0))
+        await store1.save()
         del store1
 
         # New instance, same path
         store2 = SqliteLearningStore("persist-test", state_dir)
-        got = store2.get("arm:a")
+        got = await store2.get("arm:a")
         assert got.alpha == 7.0
         assert got.beta == 2.0
         assert got.pulls == 10
         assert got.total_reward == 7.0
 
-    def test_context_partitioning_persists(self, state_dir):
+    async def test_context_partitioning_persists(self, state_dir):
         store1 = SqliteLearningStore("ctx-persist", state_dir)
-        store1.put("arm:a", ArmState(alpha=5.0), context={"task": "x"})
-        store1.put("arm:a", ArmState(alpha=9.0), context={"task": "y"})
-        store1.save()
+        await store1.put("arm:a", ArmState(alpha=5.0), context={"task": "x"})
+        await store1.put("arm:a", ArmState(alpha=9.0), context={"task": "y"})
+        await store1.save()
         del store1
 
         store2 = SqliteLearningStore("ctx-persist", state_dir)
-        assert store2.get("arm:a", context={"task": "x"}).alpha == 5.0
-        assert store2.get("arm:a", context={"task": "y"}).alpha == 9.0
+        assert (await store2.get("arm:a", context={"task": "x"})).alpha == 5.0
+        assert (await store2.get("arm:a", context={"task": "y"})).alpha == 9.0
 
-    def test_lazy_connection(self, state_dir):
+    async def test_lazy_connection(self, state_dir):
         store = SqliteLearningStore("lazy-test", state_dir)
         # First call triggers connection; verify by checking DB file exists after
         import os
         db_path = os.path.join(state_dir, "lazy-test.db")
         assert not os.path.exists(db_path)
-        store.get("arm:a")
+        await store.get("arm:a")
         assert os.path.exists(db_path)
 
 

--- a/tests/test_mastra_mcp_dogfood.py
+++ b/tests/test_mastra_mcp_dogfood.py
@@ -351,7 +351,7 @@ class TestMCPFullMastraLoop:
     6. Re-query
     """
 
-    def test_complete_mcp_workflow(self):
+    async def test_complete_mcp_workflow(self):
         setup_graph_server()
 
         # 1. Status (health check)
@@ -381,7 +381,7 @@ class TestMCPFullMastraLoop:
         assert isinstance(rules_result["rules"], list)
 
         # 5. Feedback (the thing Mastra can't do natively)
-        feedback_result = mcp_server._feedback_impl(
+        feedback_result = await mcp_server._feedback_impl(
             query_id=query_id,
             outcomes={query_result["items"][0]["id"]: "accepted"},
             source="mastra-mcp-dogfood",
@@ -434,7 +434,7 @@ class TestMCPFullMastraLoop:
             assert "id" in rule
             assert "text" in rule
 
-    def test_all_mcp_responses_json_serializable(self):
+    async def test_all_mcp_responses_json_serializable(self):
         """Every MCP response must survive JSON roundtrip (stdio transport)."""
         setup_graph_server()
 
@@ -461,7 +461,7 @@ class TestMCPFullMastraLoop:
 
         # Feedback
         if query["items"]:
-            fb = mcp_server._feedback_impl(
+            fb = await mcp_server._feedback_impl(
                 query["query_id"],
                 {query["items"][0]["id"]: "accepted"},
             )

--- a/tests/test_mastra_vector_dogfood.py
+++ b/tests/test_mastra_vector_dogfood.py
@@ -411,7 +411,7 @@ class TestGraphEnhancedExtras:
         r = _rules_impl(categories=["operational"])
         assert all(rule["category"] == "operational" for rule in r["rules"])
 
-    def test_feedback_loop(self):
+    async def test_feedback_loop(self):
         """Feedback adjusts future retrieval (the learning loop)."""
         q1 = _query_impl("OAuth2", domains=["security"], top_k=4)
         assert len(q1["items"]) > 0
@@ -421,7 +421,7 @@ class TestGraphEnhancedExtras:
         for item in q1["items"]:
             outcomes[item["id"]] = "accepted" if "OAuth" in item["content"] else "rejected"
 
-        r = _feedback_impl(q1["query_id"], outcomes)
+        r = await _feedback_impl(q1["query_id"], outcomes)
         assert r["status"] == "recorded"
         assert r["outcome_count"] == len(outcomes)
 
@@ -486,7 +486,7 @@ class TestFullDropInSimulation:
     would perform when using @peleke/mastra-qortex.
     """
 
-    def test_mastra_app_workflow(self):
+    async def test_mastra_app_workflow(self):
         # === Phase 1: Standard MastraVector operations ===
 
         # Create index (Mastra calls createIndex)
@@ -552,7 +552,7 @@ class TestFullDropInSimulation:
         assert len(rules["rules"]) >= 1
 
         # Submit feedback (the learning loop)
-        fb = _feedback_impl(
+        fb = await _feedback_impl(
             tq["query_id"],
             {tq["items"][0]["id"]: "accepted"},
             source="mastra",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -277,8 +277,8 @@ class TestQortexQuery:
 
 
 class TestQortexFeedback:
-    def test_feedback_returns_recorded(self, configured_server):
-        result = mcp_server._feedback_impl(
+    async def test_feedback_returns_recorded(self, configured_server):
+        result = await mcp_server._feedback_impl(
             query_id="test-qid",
             outcomes={"item1": "accepted", "item2": "rejected"},
             source="test",
@@ -287,15 +287,15 @@ class TestQortexFeedback:
         assert result["outcome_count"] == 2
         assert result["source"] == "test"
 
-    def test_feedback_with_default_source(self, configured_server):
-        result = mcp_server._feedback_impl(
+    async def test_feedback_with_default_source(self, configured_server):
+        result = await mcp_server._feedback_impl(
             query_id="test-qid",
             outcomes={"item1": "accepted"},
         )
         assert result["source"] == "unknown"
 
-    def test_feedback_empty_outcomes(self, configured_server):
-        result = mcp_server._feedback_impl(
+    async def test_feedback_empty_outcomes(self, configured_server):
+        result = await mcp_server._feedback_impl(
             query_id="test-qid",
             outcomes={},
         )
@@ -463,7 +463,7 @@ class TestIngestQueryRoundtrip:
 
         Path(path).unlink()
 
-    def test_ingest_then_query_with_feedback(self, configured_server, backend, embedding):
+    async def test_ingest_then_query_with_feedback(self, configured_server, backend, embedding):
         """Full loop: ingest → query → feedback."""
         from qortex_ingest.base import StubLLMBackend
 
@@ -481,7 +481,7 @@ class TestIngestQueryRoundtrip:
         query_result = mcp_server._query_impl(context="Test description")
         query_id = query_result["query_id"]
 
-        feedback_result = mcp_server._feedback_impl(
+        feedback_result = await mcp_server._feedback_impl(
             query_id=query_id,
             outcomes={"test:TestNode": "accepted"},
             source="test-harness",

--- a/tests/test_vector_mcp.py
+++ b/tests/test_vector_mcp.py
@@ -523,21 +523,21 @@ class TestDimensionValidation:
 class TestFeedbackValidation:
     """Validates that feedback rejects invalid outcome values."""
 
-    def test_valid_outcomes(self):
-        result = _feedback_impl(
+    async def test_valid_outcomes(self):
+        result = await _feedback_impl(
             "q1",
             {"item1": "accepted", "item2": "rejected", "item3": "partial"},
         )
         assert result["status"] == "recorded"
 
-    def test_invalid_outcome(self):
-        result = _feedback_impl(
+    async def test_invalid_outcome(self):
+        result = await _feedback_impl(
             "q1",
             {"item1": "accepted", "item2": "invalid_value"},
         )
         assert "error" in result
         assert "invalid_value" in result["error"]
 
-    def test_empty_outcomes(self):
-        result = _feedback_impl("q1", {})
+    async def test_empty_outcomes(self):
+        result = await _feedback_impl("q1", {})
         assert result["status"] == "recorded"

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3298,6 +3307,7 @@ name = "qortex"
 version = "0.3.3"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "fastmcp" },
     { name = "numpy" },
     { name = "pyventus" },
@@ -3385,6 +3395,7 @@ vec-sqlite = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.18" },
     { name = "asyncpg", marker = "extra == 'source-postgres'", specifier = ">=0.29" },
     { name = "chirho", marker = "extra == 'causal-full'", specifier = ">=0.2" },


### PR DESCRIPTION
## Summary
- `LearningStore` protocol: all 6 methods → `async def`
- `SqliteLearningStore`: `sqlite3` → `aiosqlite` for non-blocking I/O on MCP hot path
- `Learner`: factory classmethod `await Learner.create()` (constructor can't be async)
- All MCP `_impl` functions + tool wrappers that touch learning store → `async def`
- 15 test files updated, 1488 tests pass

## Test plan
- [x] `uv run pytest` — 1488 passed, 0 failed
- [ ] Verify no behavioral change (same MCP tool responses)
- [ ] Verify aiosqlite connection cleanup in long-running server

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)