### PR TITLE
feat: product tool suite (compare, stats, docstrings, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,70 +2,93 @@
 
 # qortex
 
-### Graph-Enhanced Retrieval Engine
+### Knowledge that learns
 
 [![PyPI](https://img.shields.io/pypi/v/qortex?style=for-the-badge&logo=pypi&logoColor=white)](https://pypi.org/project/qortex/)
 [![Python](https://img.shields.io/pypi/pyversions/qortex?style=for-the-badge&logo=python&logoColor=white)](https://pypi.org/project/qortex/)
 [![CI](https://img.shields.io/github/actions/workflow/status/Peleke/qortex/ci.yml?branch=main&style=for-the-badge&logo=github&label=CI)](https://github.com/Peleke/qortex/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
-Transforms unstructured content into a knowledge graph. Typed edges encode semantic relationships (REQUIRES, REFINES, USES). Personalized PageRank scores results by graph structure, and feedback from consumers adjusts rankings over time.
-
-[Install](#install) · [Quick Start](#quick-start) · [Framework Adapters](#framework-adapters) · [Docs](https://peleke.github.io/qortex/)
+Your AI assistant forgets everything between conversations. qortex adds a knowledge graph that learns from every interaction. One command to install. Zero config.
 
 </div>
 
-## Features
-
-- **Graph-enhanced retrieval**: Vector similarity + PPR over typed edges (REQUIRES, REFINES, USES...)
-- **Explore and navigate**: Traverse typed edges, discover neighbors and linked rules from any search result
-- **Rules auto-surfaced**: Query results include linked rules with relevance scores; no separate rules request needed
-- **Feedback-driven learning**: Consumer outcomes adjust PPR teleportation factors; results improve over time
-- **Framework adapters**: Drop-in for [LangChain](https://github.com/Peleke/langchain-qortex), [Mastra](https://github.com/Peleke/mastra-qortex), and any MCP client
-- **Flexible ingestion**: PDF, Markdown, and text sources into a unified knowledge graph
-- **Projection pipeline**: Source, Enricher, Target architecture for rule generation
-- **Multiple backends**: InMemory (testing), Memgraph (production with MAGE algorithms)
-
 ## Install
 
+**Claude Code**
 ```bash
-pip install qortex            # Core: numpy, fastmcp, typer, pyyaml
-pip install qortex[vec]       # + sentence-transformers (text-level search)
-pip install qortex[vec-sqlite] # + sqlite-vec (persistent vector index)
-pip install qortex[memgraph]  # + neo4j driver (production graph backend)
-pip install qortex[all]       # Everything
+claude mcp add qortex -- uvx qortex mcp-serve
 ```
 
-### What's included where
+**Cursor / Windsurf**
+```bash
+uvx qortex mcp-serve  # add as stdio MCP server in settings
+```
 
-| Capability | Install | What you get |
-|-----------|---------|-------------|
-| Vector-level MCP tools (`qortex_vector_*`) | `pip install qortex` | Create indexes, upsert/query raw vectors, metadata filters. Consumers provide their own embeddings. |
-| Text-level search (`qortex_query`) | `pip install qortex[vec]` | qortex embeds your text with sentence-transformers. Adds ~2GB for PyTorch + model weights. |
-| Persistent vectors | `pip install qortex[vec-sqlite]` | SqliteVec index survives restarts. Without this, vectors are in-memory only. |
-| Production graph | `pip install qortex[memgraph]` | Memgraph backend with MAGE algorithms for real PPR. Default is in-memory. |
+**Any MCP client**
+```bash
+pip install qortex[all] && qortex mcp-serve
+```
 
-**For MCP consumers** (Mastra, Claude Desktop, etc.) that provide their own embeddings: the base `pip install qortex` is sufficient. The `[vec]` extra is only needed if you want qortex to embed text for you.
+## What happens next
 
-## Quick start
+Once installed, your assistant automatically:
 
-### Search, explore, learn
+1. **Searches** the knowledge graph before answering architecture questions
+2. **Retrieves** relevant concepts, relationships, and rules (not just similar text)
+3. **Learns** from your feedback: accepted results get boosted, rejected ones get suppressed
+4. **Persists** everything to SQLite so knowledge survives restarts
+
+No config files. No API keys for the knowledge layer. Just start asking questions.
+
+## The difference
+
+| | Vanilla RAG | qortex |
+|---|---|---|
+| **Retrieval** | Cosine similarity (what's textually similar) | Graph-enhanced (what's structurally relevant) |
+| **Context** | Flat chunks | Concepts + typed edges + rules |
+| **Learning** | Static | Adapts from every accept/reject signal |
+| **Cross-references** | None | Traverses REQUIRES, REFINES, USES edges |
+
+## Prove it
+
+Call `qortex_compare` to see the difference on your own data:
+
+```json
+{
+  "summary": "Graph-enhanced retrieval found 2 item(s) that cosine missed, surfaced 1 rule(s), replaced 1 distractor(s).",
+  "diff": {
+    "graph_found_that_cosine_missed": [
+      {"rank": 3, "id": "security:JWTValidation", "score": 0.72}
+    ],
+    "cosine_found_that_graph_dropped": [
+      {"rank": 4, "id": "security:PasswordHashing", "score": 0.68}
+    ],
+    "rank_changes": [
+      {"id": "security:AuthMiddleware", "vec_rank": 3, "graph_rank": 1, "delta": 2}
+    ]
+  }
+}
+```
+
+Graph retrieval promotes structurally connected concepts (AuthMiddleware depends on JWTValidation) and demotes textually similar but unrelated results.
+
+## How it works
+
+- **Auto-ingest**: Feed it docs, specs, or code. LLM extraction builds concepts, typed edges, and rules automatically.
+- **Graph retrieval**: Queries combine vector similarity with structural graph traversal. Related concepts get promoted even if they don't share keywords.
+- **Adaptive learning**: Every `qortex_feedback` call updates retrieval weights. The system gets smarter the more you use it.
+- **Persistent by default**: SQLite stores the knowledge graph, vector index, and learning state across restarts.
+
+## For framework authors
+
+### agno KnowledgeProtocol
 
 ```python
-from qortex.client import LocalQortexClient
+from qortex.adapters.agno import QortexKnowledgeSource
 
-client = LocalQortexClient(vector_index, backend, embedding, mode="graph")
-
-# Search: vec + graph combined scoring, rules auto-surfaced
-result = client.query("OAuth2 authorization", domains=["security"], top_k=5)
-
-# Explore: traverse typed edges from any result
-explore = client.explore(result.items[0].node_id)
-for edge in explore.edges:
-    print(f"{edge.source_id} --{edge.relation_type}--> {edge.target_id}")
-
-# Feedback: close the learning loop
-client.feedback(result.query_id, {result.items[0].id: "accepted"})
+knowledge = QortexKnowledgeSource(domains=["security"])
+agent = Agent(knowledge=knowledge)
 ```
 
 ### LangChain VectorStore
@@ -74,7 +97,6 @@ client.feedback(result.query_id, {result.items[0].id: "accepted"})
 from langchain_qortex import QortexVectorStore
 
 vs = QortexVectorStore.from_texts(texts, embedding, domain="security")
-docs = vs.similarity_search("authentication", k=5)
 retriever = vs.as_retriever()
 ```
 
@@ -87,58 +109,27 @@ import { QortexVector } from "@peleke.s/mastra-qortex";
 
 const qortex = new QortexVector({ id: "qortex" });
 await qortex.createIndex({ indexName: "docs", dimension: 384 });
-await qortex.upsert({ indexName: "docs", vectors: embeddings, metadata });
 const results = await qortex.query({ indexName: "docs", queryVector: q, topK: 10 });
 ```
 
 See [@peleke.s/mastra-qortex](https://github.com/Peleke/mastra-qortex) for the standalone package.
 
-### MCP server
-
-```bash
-qortex mcp-serve  # stdio transport, works with Claude Desktop / any MCP client
-```
-
-Tools: `qortex_query`, `qortex_explore`, `qortex_rules`, `qortex_feedback`, `qortex_ingest`, `qortex_domains`, `qortex_status`, plus 9 vector-level tools (`qortex_vector_*`).
-
-### Project rules
-
-```python
-from qortex.projectors.projection import Projection
-from qortex.projectors.sources.flat import FlatRuleSource
-from qortex.projectors.targets.buildlog_seed import BuildlogSeedTarget
-
-projection = Projection(
-    source=FlatRuleSource(backend=backend),
-    target=BuildlogSeedTarget(persona_name="my_rules"),
-)
-result = projection.project(domains=["my_domain"])
-```
-
-## Framework adapters
-
 | Framework | Package | Language | Interface |
 |-----------|---------|----------|-----------|
+| agno | Built-in adapter | Python | `KnowledgeProtocol` |
 | LangChain | [`langchain-qortex`](https://github.com/Peleke/langchain-qortex) | Python | `VectorStore` ABC |
 | Mastra | [`@peleke.s/mastra-qortex`](https://github.com/Peleke/mastra-qortex) | TypeScript | `MastraVector` abstract class |
 | Any MCP client | Built-in MCP server | Any | MCP tools (JSON-RPC) |
 
-## Architecture
+## Install extras
 
-```
-Sources (PDF/MD/Text)
-  -> Ingestion (LLM extraction -> concepts + typed edges + rules)
-    -> Knowledge Graph (InMemoryBackend | Memgraph)
-      -> VectorIndex (NumpyVectorIndex | SqliteVecIndex)
-        -> Retrieval (PPR + cosine -> combined scoring)
-          -> Consumers (LangChain, Mastra, MCP, buildlog, agents)
-```
-
-## Documentation
-
-- [Full docs](https://peleke.github.io/qortex/)
-- [LangChain integration](https://github.com/Peleke/langchain-qortex)
-- [Mastra integration](https://github.com/Peleke/mastra-qortex)
+| Capability | Install | What you get |
+|-----------|---------|-------------|
+| Core + MCP tools | `pip install qortex` | Knowledge graph, MCP server, vector-level tools. Consumers provide embeddings. |
+| Text-level search | `pip install qortex[vec]` | qortex embeds text with sentence-transformers. Adds ~2GB for PyTorch + model weights. |
+| Persistent vectors | `pip install qortex[vec-sqlite]` | SQLite-backed vector index. Without this, vectors are in-memory only. |
+| Production graph | `pip install qortex[memgraph]` | Memgraph backend for production-scale graph operations. |
+| Everything | `pip install qortex[all]` | All of the above. |
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "qortex"
 version = "0.3.8"
-description = "Knowledge graph ingestion engine for automated rule generation"
+description = "Knowledge graph that learns from every interaction. MCP server, graph retrieval, adaptive learning."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3295,7 +3295,7 @@ wheels = [
 
 [[package]]
 name = "qortex"
-version = "0.3.3"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Add `qortex_compare` tool: runs the same query through cosine-only and graph-enhanced retrieval, diffs results, surfaces rules the graph found
- Add `qortex_stats` tool: knowledge coverage, learning progress, activity counters, persistence info
- Rewrite 9 tool docstrings to remove internal jargon (PPR, teleportation, FlatRuleSource, Phase refs)
- Rewrite README with product-focused structure: install, what happens next, comparison table, prove-it section, framework adapters
- Update module docstring to list all 33 tools by category
- Update pyproject.toml description to match new positioning

64 tests, all passing.

## Test plan

- [x] `uv run pytest tests/test_mcp_server.py -v` -- 64/64 green
- [x] `uv run pytest tests/ -v` -- full suite green (pre-existing Memgraph failures only)
- [x] Jargon grep: zero banned terms (PPR, teleportation, FlatRuleSource, Phase) in tool docstrings
- [x] Gauntlet loop: clean on iteration 2
- [x] BMAD adversarial review: critical node_id bug found and fixed
- [x] P0 test gaps closed: invalid feedback outcome, query error counter, stats with real Learner

🤖 Generated with [Claude Code](https://claude.com/claude-code)