### PR TITLE
docs: sync API reference, installation, CLI, and concepts (#100)

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,28 +15,32 @@ This gives you the knowledge graph, MCP server, and vector-level tools. Consumer
 
 ## Optional Dependencies
 
-qortex has several optional dependency groups for different capabilities:
+qortex has 13 optional dependency groups for different capabilities:
 
-| Capability | Install | What you get |
-|-----------|---------|-------------|
-| Core + MCP tools | `pip install qortex` | Knowledge graph, MCP server, vector-level tools. Consumers provide embeddings. |
-| Text-level search | `pip install qortex[vec]` | qortex embeds text with sentence-transformers. Adds ~2GB for PyTorch + model weights. |
-| Persistent vectors | `pip install qortex[vec-sqlite]` | SQLite-backed vector index. Without this, vectors are in-memory only. |
-| PDF ingestion | `pip install qortex[pdf]` | PDF parsing via PyMuPDF and pdfplumber. |
-| LLM enrichment | `pip install qortex[llm]` | Anthropic SDK for LLM-powered rule enrichment. |
-| Production graph | `pip install qortex[memgraph]` | Memgraph backend for production-scale graph operations. |
-| Causal analysis | `pip install qortex[causal]` | NetworkX for DAG support and d-separation. |
-| Causal inference | `pip install qortex[causal-dowhy]` | DoWhy for causal inference and refutation. |
-| Bayesian causal | `pip install qortex[causal-full]` | Pyro + ChirHo for full Bayesian causal modeling. |
-| PostgreSQL sources | `pip install qortex[source-postgres]` | asyncpg for ingesting from PostgreSQL databases. |
-| Observability | `pip install qortex[observability]` | OpenTelemetry + Prometheus for metrics and tracing. |
-| Everything | `pip install qortex[all]` | All of the above plus dev tools. |
+| Group | Install | What it adds |
+|-------|---------|--------------|
+| (core) | `pip install qortex` | Knowledge graph, MCP server, vector-level tools, `qortex-observe` logging. Consumers provide embeddings. |
+| `vec` | `pip install qortex[vec]` | sentence-transformers for text embedding. Adds ~2GB for PyTorch + model weights. |
+| `vec-sqlite` | `pip install qortex[vec-sqlite]` | SQLite-backed vector index via sqlite-vec. Without this, vectors are in-memory only. Includes `vec`. |
+| `pdf` | `pip install qortex[pdf]` | PDF parsing via PyMuPDF and pdfplumber. |
+| `llm` | `pip install qortex[llm]` | Anthropic SDK for LLM-powered extraction and rule enrichment. |
+| `memgraph` | `pip install qortex[memgraph]` | neo4j driver for the Memgraph production graph backend. |
+| `mcp` | `pip install qortex[mcp]` | fastmcp (also a core dependency, so this is a no-op unless pinning). |
+| `causal` | `pip install qortex[causal]` | NetworkX for causal DAG support and d-separation queries. |
+| `causal-dowhy` | `pip install qortex[causal-dowhy]` | NetworkX + DoWhy for causal inference and refutation. |
+| `causal-full` | `pip install qortex[causal-full]` | NetworkX + Pyro + ChirHo for full Bayesian causal modeling. |
+| `source-postgres` | `pip install qortex[source-postgres]` | asyncpg for connecting to and ingesting from PostgreSQL databases. |
+| `observability` | `pip install qortex[observability]` | qortex-observe with OpenTelemetry exporters for distributed tracing and Prometheus metrics. |
+| `dev` | `pip install qortex[dev]` | pytest, ruff, mypy, hypothesis, and other development/testing tools. |
+| `all` | `pip install qortex[all]` | All of the above (except `causal-dowhy` and `causal-full`). |
 
 ### Which groups do I need?
 
 - **Trying it out?** Start with `pip install qortex[vec]` for embedded text search.
 - **Persistent storage?** Add `vec-sqlite` so vectors survive restarts: `pip install qortex[vec-sqlite]`.
 - **Production?** Use `pip install qortex[all]` and configure Memgraph for graph operations.
+- **Database sources?** Add `source-postgres` to connect to PostgreSQL and ingest schemas or row data.
+- **Observability?** Add `observability` for OpenTelemetry traces and Prometheus metrics via qortex-observe.
 - **Framework integration only?** Plain `pip install qortex` is enough if your framework (LangChain, agno) provides embeddings.
 
 ## MCP Server

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,6 +19,8 @@ qortex <command> --help  # Show command help
 | `inspect` | Graph inspection |
 | `viz` | Visualization and queries |
 | `interop` | Consumer interop protocol |
+| `prune` | Edge pruning and analysis |
+| `mcp-serve` | Start the MCP server (top-level command) |
 
 ---
 
@@ -363,16 +365,96 @@ signals:
 
 ---
 
+## prune
+
+Prune and analyze graph edges from saved manifests.
+
+### `qortex prune manifest <path>`
+
+Apply the 6-step pruning pipeline to edges in a saved manifest:
+
+1. Minimum evidence length
+2. Confidence floor
+3. Jaccard deduplication
+4. Competing relation resolution
+5. Isolated weak edge removal
+6. Structural/causal layer tagging
+
+```bash
+# Preview what would be pruned
+qortex prune manifest ch05.manifest.json --dry-run
+
+# Prune with custom thresholds and save
+qortex prune manifest ch05.manifest.json -c 0.6 -o pruned.json
+
+# Show details of dropped edges
+qortex prune manifest ch05.manifest.json --show-dropped
+```
+
+Options:
+- `--dry-run / -n`: Show what would be pruned without modifying
+- `--min-confidence / -c`: Confidence floor (default: 0.55)
+- `--min-evidence / -e`: Minimum evidence tokens (default: 8)
+- `--output / -o`: Output path for pruned manifest
+- `--show-dropped`: Show details of dropped edges
+
+### `qortex prune stats <path>`
+
+Show edge statistics without pruning. Displays confidence distribution, relation type breakdown, layer breakdown, and evidence quality metrics.
+
+```bash
+qortex prune stats ch05.manifest.json
+```
+
+Output:
+```
+Edge Statistics for: ch05.manifest.json
+  Total edges: 119
+  Total concepts: 285
+  Edge density: 0.42 edges/concept
+
+Confidence distribution:
+      <0.55:    5 (  4.2%)
+  0.55-0.70:   23 ( 19.3%)
+  0.70-0.85:   51 ( 42.9%)
+     >=0.85:   40 ( 33.6%)
+```
+
+---
+
+## mcp-serve
+
+### `qortex mcp-serve`
+
+Start the qortex MCP server.
+
+```bash
+# Default: stdio transport
+qortex mcp-serve
+
+# SSE transport (for web clients)
+qortex mcp-serve --transport sse
+```
+
+Options:
+- `--transport`: Transport protocol: `"stdio"` or `"sse"` (default: `"stdio"`)
+
+---
+
 ## Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `MEMGRAPH_HOST` | Memgraph hostname | localhost |
-| `MEMGRAPH_PORT` | Memgraph port | 7687 |
+| `MEMGRAPH_HOST` | Memgraph hostname | `localhost` |
+| `MEMGRAPH_PORT` | Memgraph port | `7687` |
 | `MEMGRAPH_USER` | Memgraph username | (none) |
 | `MEMGRAPH_PASSWORD` | Memgraph password | (none) |
-| `ANTHROPIC_API_KEY` | Anthropic API key for LLM enrichment | (none) |
-| `QORTEX_CONFIG` | Config file path | ~/.claude/qortex-consumers.yaml |
+| `ANTHROPIC_API_KEY` | Anthropic API key for LLM extraction and enrichment | (none) |
+| `QORTEX_CONFIG` | Config file path | `~/.claude/qortex-consumers.yaml` |
+| `QORTEX_VEC` | Vector layer backend: `memory` or `sqlite` | `sqlite` |
+| `QORTEX_GRAPH` | Graph layer backend: `memory` or `memgraph` | `memory` |
+| `QORTEX_STATE_DIR` | Override for learning state persistence directory | (none) |
+| `OLLAMA_HOST` | Ollama server URL for local LLM extraction | `http://localhost:11434` |
 
 ---
 


### PR DESCRIPTION
## Summary

- **docs/reference/api.md**: Updated MCP Tools section to document all 33 tools (was missing source, vector, and learning tools; had incorrect parameters for `qortex_ingest_text`, `qortex_ingest_structured`, `qortex_query`, and `qortex_rules`). Tools are now organized by category: Core (11), Source (7), Vector (9), Learning (6). Each tool has accurate parameters, types, defaults, and return shapes matching `server.py`.
- **docs/getting-started/installation.md**: Updated optional dependency table from 11 to 13 groups. Added `mcp` and `dev` groups, added `source-postgres` and `observability` to the "Which groups do I need?" section.
- **docs/reference/cli.md**: Added `prune` command group (`qortex prune manifest`, `qortex prune stats`) and `mcp-serve` top-level command. Added missing environment variables: `QORTEX_VEC`, `QORTEX_GRAPH`, `QORTEX_STATE_DIR`, `OLLAMA_HOST`.
- **docs/getting-started/concepts.md**: Added Vector Indexing section (NumpyVectorIndex vs SqliteVecIndex, named index registry), Adaptive Learning section (Learner, LearningStore protocol, credit propagation), and Observability section (qortex-observe, structured logging, event system, MCP tracing, carbon tracking).

Closes #100

## Test plan

- [ ] Verify all 33 MCP tool names in api.md match `server.py` tool decorators
- [ ] Verify parameter tables match actual function signatures
- [ ] Verify all 13 optional dependency groups match `pyproject.toml`
- [ ] Verify CLI commands match `src/qortex/cli/__init__.py` command groups
- [ ] Check that mkdocs build succeeds (if configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)