### PR TITLE
docs: rewrite homepage to match product positioning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: qortex
 site_url: https://peleke.github.io/qortex/
-site_description: Knowledge graph ingestion engine for automated rule generation
+site_description: Persistent, learning memory for AI agents
 repo_url: https://github.com/Peleke/qortex
 repo_name: Peleke/qortex
 


### PR DESCRIPTION
## Summary
- Rewrites docs homepage to position qortex as persistent, learning memory for AI agents (not a rule generation engine)
- Leads with MCP install commands, RAG comparison table, and `qortex_compare` proof
- Adds framework adapter section with code examples and full compatibility table
- Fixes `site_description` in mkdocs.yml
- Removes broken Material theme icons that don't render on readthedocs theme

Closes #100 (P3: docs/index.md opening doesn't match README's product-focused tone)

## Test plan
- [x] `mkdocs build` succeeds (no new warnings)
- [ ] Verify deployed site renders correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)