### PR TITLE
docs: fix rule-engine framing across gateway pages

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-qortex is a knowledge graph ingestion engine that transforms unstructured content into actionable rules for AI agents.
+qortex is persistent, learning memory for AI agents. It builds a knowledge graph from your content and combines vector similarity with graph traversal so retrieval improves from every feedback signal.
 
 ## High-Level Architecture
 
@@ -16,8 +16,8 @@ Each layer has a single responsibility:
 |-------|----------------|
 | Ingestion | Parse sources, extract concepts, produce manifests |
 | Knowledge Graph | Store concepts/edges/rules, provide queries |
-| Projection | Transform KG into rules, enrich, serialize |
-| Interop | Distribute seeds, coordinate consumers |
+| Projection | Transform KG into consumable formats (rules, seeds, schemas) |
+| Interop | Distribute outputs, coordinate consumers |
 
 ### 2. Protocol-Driven Design
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,6 +1,6 @@
 # Core Concepts
 
-qortex is built around a knowledge graph model that captures concepts, their relationships, and actionable rules.
+qortex is built around a knowledge graph that stores concepts and typed relationships. The graph also records feedback signals, so retrieval improves over time. Rules are one output format; the graph itself is the persistent layer.
 
 ## The Knowledge Graph
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -100,5 +100,5 @@ See [Using Memgraph](../guides/memgraph.md) for detailed setup instructions.
 
 ## Next Steps
 
-- [Quick Start](quickstart.md) - Project your first rules
+- [Quick Start](quickstart.md) - Build a graph and run your first query
 - [Core Concepts](concepts.md) - Understand the data model

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-This guide walks you through projecting rules from a knowledge graph in under 5 minutes.
+This guide walks you through building a knowledge graph and running your first query in under 5 minutes.
 
 ## 1. Create a Backend
 

--- a/docs/guides/consumer-integration.md
+++ b/docs/guides/consumer-integration.md
@@ -1,6 +1,6 @@
 # Consumer Integration
 
-qortex uses a consumer interop protocol that allows ANY system to consume projected rules, not just buildlog.
+qortex uses a consumer interop protocol that allows any system to consume projected knowledge (rules, schemas, seeds), not just buildlog.
 
 ## Architecture
 

--- a/docs/guides/querying.md
+++ b/docs/guides/querying.md
@@ -1,6 +1,6 @@
 # Querying the Knowledge Graph
 
-qortex is both an ingestion engine and a retrieval system. The query layer lets you search your knowledge graph, explore its structure, and improve results through feedback.
+The query layer combines vector similarity with graph traversal to surface structurally relevant results. You can explore the graph from any result and submit feedback that updates retrieval weights.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Rewrites opening lines on 6 gateway pages that still said "ingestion engine" or "rule generation"
- architecture/overview.md, concepts.md, quickstart.md, installation.md, querying.md, consumer-integration.md
- Prose checked against Bragi gauntlet rules (no tricolons, no em-dashes, no inflated significance)
- Follow-up to #118 which fixed the homepage

## Test plan
- [x] `mkdocs build` succeeds (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)