### PR TITLE
chore: bump version to 0.5.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qortex"
-version = "0.5.2"
+version = "0.5.3"
 description = "Knowledge graph that learns from every interaction. MCP server, graph retrieval, adaptive learning."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Version bump for emission ingestion feature + junk rule filtering

## Changes in 0.5.3
- `qortex ingest emissions` — ingest buildlog emission artifacts into KG (no LLM needed)
- `--bridge` flag creates cross-domain edges from gauntlet rules to design pattern domains
- Filters out inactive and derived junk rules (BaseballReporter, etc.)
- 34 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)