### PR TITLE
docs(online): comprehensive README with SVG diagram

### DIFF
--- a/docs/guides/online-indexing.md
+++ b/docs/guides/online-indexing.md
@@ -1,6 +1,6 @@
 # Online Indexing
 
-Online indexing adds conversation turns to the knowledge graph in real time via the `qortex_ingest_message` and `qortex_ingest_tool_result` MCP tools. No LLM is needed -- chunking and embedding run locally.
+Online indexing adds conversation turns to the knowledge graph in real time via the `qortex_ingest_message` and `qortex_ingest_tool_result` MCP tools. Concept extraction runs locally via spaCy (default) or optionally via LLM. No external API key is required for the default configuration.
 
 ## MCP Tools
 
@@ -21,9 +21,10 @@ Returns:
 {
   "session_id": "s1",
   "chunks": 3,
-  "concepts": 3,
-  "edges": 2,
-  "latency_ms": 12.5
+  "concepts": 8,
+  "edges": 5,
+  "extracted_concepts": 5,
+  "latency_ms": 42.3
 }
 ```
 
@@ -60,12 +61,28 @@ Text input
   │  - VectorIndex.add(ids, embeddings)
   │  - IDs prefixed with session_id: "{session_id}:{chunk_id}"
   ▼
-4. Graph nodes
-  │  - One ConceptNode per chunk
-  │  - name = first 80 chars of text
-  │  - description = full chunk text
-  │  - domain = provided domain parameter
-  │  - source_id = "{session_id}:{role}" or "{session_id}:tool:{tool_name}"
+4. Per-chunk processing (for each chunk):
+  │
+  │  4a. Chunk node (vec bridge)
+  │  │  - ConceptNode with name = first 80 chars of text
+  │  │  - description = full chunk text, domain and source_id from params
+  │  │  - This node bridges vec search → graph traversal
+  │  │
+  │  4b. Concept extraction
+  │  │  - Runs the active ExtractionStrategy on chunk text
+  │  │  - Returns ExtractedConcepts (named entities, noun phrases)
+  │  │  - Returns ExtractedRelations (typed relationships)
+  │  │
+  │  4c. Concept nodes + CONTAINS edges
+  │  │  - One ConceptNode per extracted concept (ID: "{prefix}:concept:{slug}")
+  │  │  - CONTAINS edge from chunk node → each concept node
+  │  │  - Properties: {"origin": "extraction"}
+  │  │
+  │  4d. Typed relation edges
+  │     - Edges between concept nodes from extraction results
+  │     - Types: USES, REQUIRES, CONTAINS, IMPLEMENTS, REFINES, SIMILAR_TO
+  │     - Confidence from extraction strategy (0.5-0.9)
+  │
   ▼
 5. Co-occurrence edges
   │  - Consecutive chunks get REQUIRES edges (confidence=0.8)
@@ -73,8 +90,10 @@ Text input
   │  - N chunks produce N-1 edges
   ▼
 6. Observability events
+     - ConceptsExtracted (per-chunk: concept_count, relation_count, strategy, latency_ms)
+     - ExtractionPipelineCompleted (aggregate: total_concepts, total_relations, strategy)
      - GraphNodesCreated(count, domain, origin="online_index")
-     - GraphEdgesCreated(count, domain, origin="co_occurrence")
+     - GraphEdgesCreated(count, domain, origin="online_index")
      - MessageIngested or ToolResultIngested (per-call event)
 ```
 
@@ -123,16 +142,90 @@ To reset to the default:
 set_chunking_strategy(None)
 ```
 
-## M3 Roadmap: Concept Extraction
+## Concept Extraction
 
-The current implementation stores raw text chunks as ConceptNodes with co-occurrence edges. M3 will add:
+The pipeline extracts named concepts and typed relationships from each chunk using a pluggable `ExtractionStrategy`. This produces a richer graph than raw text nodes alone: PPR traverses from chunk nodes through CONTAINS edges to named concept nodes, then follows typed relation edges to discover related concepts.
 
-- **Named entity extraction**: identify people, tools, concepts from text.
-- **Typed relationships**: CAUSES, REQUIRES, RELATES_TO edges (not just co-occurrence).
-- **Cross-session merging**: deduplicate concepts across sessions.
-- **Temporal decay**: reduce weight of older concepts over time.
+### Extraction strategies
 
-Until then, retrieval quality relies on vector similarity + PPR over co-occurrence structure + any manually ingested knowledge.
+Set via `QORTEX_EXTRACTION` environment variable:
+
+| Value | Strategy | Description |
+|-------|----------|-------------|
+| `spacy` (default) | `SpaCyExtractor` | NER + noun chunks + dependency-parse relation inference. Fast, local, no API key. |
+| `llm` | `LLMExtractor` | Wraps the qortex-ingest `LLMBackend` (Anthropic or Ollama). Higher quality, requires API key or local model. |
+| `none` | `NullExtractor` | No extraction. Chunk nodes use raw text[:80] as names. |
+
+### SpaCy extractor (default)
+
+The default strategy uses spaCy's `en_core_web_sm` model:
+
+1. **Named entity recognition**: Extracts PERSON, ORG, PRODUCT, GPE, WORK_OF_ART, EVENT, FAC, LAW, LANGUAGE, NORP entities (confidence 0.9).
+2. **Noun chunk extraction**: Extracts noun phrases not already covered by NER (confidence 0.7).
+3. **Span deduplication**: Prefers NER entities over noun chunks when spans overlap.
+4. **Relation inference** from dependency parse:
+   - Subject-verb-object with "use/call/invoke" verbs → USES
+   - Subject-verb-object with "require/need/depend/import" → REQUIRES
+   - "contain/include/have" → CONTAINS
+   - "implement/extend/inherit" → IMPLEMENTS
+   - "refine/specialize/customize" → REFINES
+   - Coordination patterns ("X and Y") → SIMILAR_TO
+
+The spaCy model is downloaded eagerly on first use. If spaCy is not installed, the extractor returns empty results and the pipeline falls back to raw text behavior.
+
+Install spaCy support:
+
+```bash
+pip install 'qortex[nlp]'
+```
+
+### LLM extractor (opt-in)
+
+Wraps the existing qortex-ingest `LLMBackend`:
+
+```bash
+export QORTEX_EXTRACTION=llm
+```
+
+Calls `extract_concepts()` and `extract_relations()` on the configured backend (Anthropic or Ollama). Higher quality extraction but incurs API costs or requires a local model.
+
+### Custom strategies
+
+Any callable matching the `ExtractionStrategy` protocol works:
+
+```python
+from qortex.mcp.server import set_extraction_strategy
+from qortex.online.extractor import ExtractionResult, ExtractedConcept
+
+class MyExtractor:
+    def __call__(self, text: str, domain: str = "") -> ExtractionResult:
+        # Your logic here
+        return ExtractionResult(concepts=[...], relations=[...])
+
+set_extraction_strategy(MyExtractor(), name="custom")
+```
+
+### Graph structure
+
+For a message like "The auth module handles JWT validation. It requires the crypto library.":
+
+```
+chunk:abc123 (name="The auth module handles JWT validation...")
+  ├── CONTAINS → concept:auth_module (name="Auth Module")
+  ├── CONTAINS → concept:jwt_validation (name="Jwt Validation")
+  └── CONTAINS → concept:crypto_library (name="Crypto Library")
+
+concept:auth_module ──USES──→ concept:jwt_validation
+concept:auth_module ──REQUIRES──→ concept:crypto_library
+```
+
+Chunk nodes remain as the bridge between vector search and the concept graph. PPR traverses: vec search → chunk node → CONTAINS → concept nodes → typed edges → more concepts.
+
+## Roadmap
+
+- **Cross-session concept merging**: Deduplicate concepts across sessions.
+- **Temporal decay**: Reduce weight of older concepts over time.
+- **Hybrid extraction**: Combine spaCy speed with LLM precision for high-value chunks.
 
 ## Observability
 
@@ -142,6 +235,8 @@ Until then, retrieval quality relies on vector similarity + PPR over co-occurren
 |-------|---------|--------|
 | `MessageIngested` | `_ingest_message_impl` | `session_id`, `role`, `domain`, `chunk_count`, `concept_count`, `edge_count`, `latency_ms` |
 | `ToolResultIngested` | `_ingest_tool_result_impl` | `tool_name`, `session_id`, `domain`, `concept_count`, `edge_count`, `latency_ms` |
+| `ConceptsExtracted` | `_online_index_pipeline` | `concept_count`, `relation_count`, `domain`, `strategy`, `latency_ms`, `chunk_index`, `source_id` |
+| `ExtractionPipelineCompleted` | `_online_index_pipeline` | `total_concepts`, `total_relations`, `total_chunks`, `domain`, `strategy`, `latency_ms`, `source_id` |
 | `GraphNodesCreated` | `_online_index_pipeline` | `count`, `domain`, `origin` |
 | `GraphEdgesCreated` | `_online_index_pipeline` | `count`, `domain`, `origin` |
 
@@ -149,6 +244,13 @@ Until then, retrieval quality relies on vector similarity + PPR over co-occurren
 
 | Metric | Type | Source Event |
 |--------|------|--------------|
+| `qortex_concepts_extracted` | Counter | `ConceptsExtracted` |
+| `qortex_relations_extracted` | Counter | `ConceptsExtracted` |
+| `qortex_extraction_duration_seconds` | Histogram | `ConceptsExtracted` |
+| `qortex_extraction_pipeline_duration_seconds` | Histogram | `ExtractionPipelineCompleted` |
+| `qortex_extraction_concepts_per_chunk` | Histogram | `ConceptsExtracted` |
+| `qortex_extraction_relations_per_chunk` | Histogram | `ConceptsExtracted` |
+| `qortex_extractions` | Counter | `ExtractionPipelineCompleted` |
 | `qortex_graph_nodes_created_total` | Counter | `GraphNodesCreated` |
 | `qortex_graph_edges_created_total` | Counter | `GraphEdgesCreated` |
 
@@ -160,17 +262,35 @@ The **KG Growth** section of the `qortex-main` dashboard shows:
 - **Nodes vs Edges over time**: time series showing growth rate.
 - **By Origin**: breakdown of `online_index` vs `manifest` vs `co_occurrence`.
 
+The **Concept Extraction** section shows:
+
+- **Extractions Total / Concepts Extracted / Relations Extracted**: lifetime stat panels.
+- **Concepts per Chunk (p50/p95)**: distribution of extraction density.
+- **Extraction Latency per chunk (p50/p95/p99)**: per-chunk extraction time.
+- **Pipeline Latency (p50/p95)**: total extraction time across all chunks.
+- **Concepts by Strategy & Domain**: breakdown by extraction strategy and domain.
+
 ### Jaeger traces
 
 When OTel is enabled (`QORTEX_OTEL_ENABLED=true`), each ingest call produces a trace tree:
 
 ```
-qortex_ingest_message
-  ├─ chunker (SentenceBoundaryChunker)
-  ├─ vec.embed.sentence_transformer
-  ├─ vec.add
-  ├─ memgraph.add_node (x N)
-  └─ memgraph.add_edge (x N-1)
+mcp.tool.qortex_ingest_message
+  └─ online_index.pipeline
+       ├─ online_index.chunk
+       ├─ online_index.embed
+       ├─ online_index.vec_add
+       ├─ online_index.add_chunk_node (x N)
+       ├─ online_index.extract_chunk (x N)
+       │    └─ extraction.spacy (or extraction.llm)
+       │         ├─ extraction.spacy.nlp_process
+       │         ├─ extraction.spacy.extract_entities
+       │         ├─ extraction.spacy.extract_noun_chunks
+       │         ├─ extraction.spacy.deduplicate
+       │         └─ extraction.spacy.infer_relations
+       ├─ online_index.add_concept_nodes (x N)
+       ├─ online_index.add_relation_edges (x N)
+       └─ online_index.co_occurrence_edges
 ```
 
 ## Next steps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - Rule Enrichment: guides/enrichment.md
     - Consumer Integration: guides/consumer-integration.md
     - Using Memgraph: guides/memgraph.md
+    - Online Indexing: guides/online-indexing.md
     - Visualizing Your Graph: guides/visualization.md
   - Theory:
     - Overview: tutorials/index.md

--- a/packages/qortex-online/README.md
+++ b/packages/qortex-online/README.md
@@ -1,10 +1,255 @@
 # qortex-online
 
-Online session indexing for qortex: chunking, concept extraction, and real-time graph wiring.
+Online session indexing for [qortex](https://github.com/Peleke/qortex): chunking, concept extraction, and real-time graph wiring.
 
-## Installation
+<div align="center">
+
+<!-- Architecture: Online Extraction Pipeline -->
+<svg viewBox="0 0 620 480" xmlns="http://www.w3.org/2000/svg" aria-label="qortex-online architecture: conversation text flows through chunking, concept extraction, and relation inference into the knowledge graph">
+  <style>
+    .onl-bg { fill: #0d1117; }
+    .onl-box { fill: #161b22; stroke: #30363d; stroke-width: 1; rx: 6; }
+    .onl-box-accent { fill: #161b22; stroke: #6366f1; stroke-width: 1.5; rx: 6; filter: url(#onl-glow); }
+    .onl-label { font-family: 'JetBrains Mono', monospace; font-size: 8px; fill: #8b949e; text-transform: uppercase; letter-spacing: 0.05em; }
+    .onl-title { font-family: system-ui, sans-serif; font-size: 13px; fill: #e6edf3; }
+    .onl-subtitle { font-family: system-ui, sans-serif; font-size: 10px; fill: #8b949e; }
+    .onl-flow { stroke: #6366f1; stroke-width: 1.2; stroke-dasharray: 4 3; fill: none; opacity: 0.5; }
+    .onl-flow-anim { animation: onl-dash 2s linear infinite; }
+    @keyframes onl-dash { to { stroke-dashoffset: -14; } }
+    .onl-arrow { fill: #6366f1; opacity: 0.5; }
+  </style>
+  <defs>
+    <filter id="onl-glow"><feGaussianBlur stdDeviation="2" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>
+  <rect width="620" height="480" class="onl-bg"/>
+
+  <!-- Input -->
+  <rect x="180" y="20" width="260" height="50" class="onl-box"/>
+  <text x="195" y="38" class="onl-label">input</text>
+  <text x="195" y="55" class="onl-title">Conversation text (MCP session)</text>
+
+  <!-- Chunking -->
+  <rect x="180" y="110" width="260" height="55" class="onl-box"/>
+  <text x="195" y="128" class="onl-label">phase 1 · chunking</text>
+  <text x="195" y="148" class="onl-title">SentenceBoundaryChunker</text>
+
+  <!-- Flow: input → chunking -->
+  <line x1="310" y1="70" x2="310" y2="110" class="onl-flow onl-flow-anim"/>
+  <polygon points="310,108 306,100 314,100" class="onl-arrow"/>
+
+  <!-- Chunking annotations -->
+  <text x="460" y="125" class="onl-subtitle">256 tokens / chunk</text>
+  <text x="460" y="140" class="onl-subtitle">32-token overlap</text>
+  <text x="460" y="155" class="onl-subtitle">SHA256 deterministic IDs</text>
+
+  <!-- Extraction (accented) -->
+  <rect x="180" y="205" width="260" height="65" class="onl-box-accent"/>
+  <text x="195" y="223" class="onl-label">phase 2 · extraction</text>
+  <text x="195" y="243" class="onl-title">ExtractionStrategy (pluggable)</text>
+  <text x="195" y="259" class="onl-subtitle">SpaCy / LLM / Null</text>
+
+  <!-- Flow: chunking → extraction -->
+  <line x1="310" y1="165" x2="310" y2="205" class="onl-flow onl-flow-anim"/>
+  <polygon points="310,203 306,195 314,195" class="onl-arrow"/>
+
+  <!-- Extractor row -->
+  <rect x="20" y="205" width="140" height="65" class="onl-box"/>
+  <text x="35" y="223" class="onl-label">spacy (default)</text>
+  <text x="35" y="243" class="onl-title">NER + noun chunks</text>
+  <text x="35" y="259" class="onl-subtitle">dep-parse relations</text>
+
+  <rect x="460" y="205" width="140" height="65" class="onl-box"/>
+  <text x="475" y="223" class="onl-label">llm (opt-in)</text>
+  <text x="475" y="243" class="onl-title">Anthropic / Ollama</text>
+  <text x="475" y="259" class="onl-subtitle">via qortex-ingest</text>
+
+  <!-- Relation Inference -->
+  <rect x="180" y="310" width="260" height="55" class="onl-box"/>
+  <text x="195" y="328" class="onl-label">phase 3 · relation inference</text>
+  <text x="195" y="348" class="onl-title">Verb patterns + coordination</text>
+
+  <!-- Flow: extraction → relations -->
+  <line x1="310" y1="270" x2="310" y2="310" class="onl-flow onl-flow-anim"/>
+  <polygon points="310,308 306,300 314,300" class="onl-arrow"/>
+
+  <!-- Relation annotations -->
+  <text x="20" y="325" class="onl-subtitle">USES, REQUIRES, CONTAINS</text>
+  <text x="20" y="340" class="onl-subtitle">IMPLEMENTS, REFINES</text>
+  <text x="20" y="355" class="onl-subtitle">SIMILAR_TO (coordination)</text>
+
+  <!-- Output: Graph -->
+  <rect x="180" y="405" width="260" height="55" class="onl-box-accent"/>
+  <text x="195" y="423" class="onl-label">output</text>
+  <text x="195" y="443" class="onl-title">ConceptNode[] + ConceptEdge[]</text>
+
+  <!-- Flow: relations → graph -->
+  <line x1="310" y1="365" x2="310" y2="405" class="onl-flow onl-flow-anim"/>
+  <polygon points="310,403 306,395 314,395" class="onl-arrow"/>
+
+  <!-- Output annotations -->
+  <text x="460" y="420" class="onl-subtitle">CONTAINS (chunk → concept)</text>
+  <text x="460" y="435" class="onl-subtitle">Typed edges (dep-parse)</text>
+  <text x="460" y="450" class="onl-subtitle">SIMILAR_TO (co-occurrence)</text>
+</svg>
+
+</div>
+
+## Install
 
 ```bash
-uv pip install qortex-online        # core (chunking + extraction protocol)
-uv pip install 'qortex-online[nlp]' # + spaCy NER extraction
+pip install qortex-online                # core (chunking + extraction protocol)
+pip install 'qortex-online[nlp]'         # + spaCy NER extraction
+pip install 'qortex-online[all]'         # everything
 ```
+
+## Quick Start
+
+```python
+from qortex.online import default_chunker, SpaCyExtractor
+
+# Chunk conversation text
+chunks = default_chunker("User said JWT tokens expire after 30 minutes. The auth module validates them.")
+
+# Extract concepts and relations
+extractor = SpaCyExtractor()
+for chunk in chunks:
+    result = extractor(chunk.text, domain="auth")
+    for concept in result.concepts:
+        print(f"  {concept.name} ({concept.confidence:.1f})")
+    for rel in result.relations:
+        print(f"  {rel.source_name} --{rel.relation_type}--> {rel.target_name}")
+```
+
+## What It Does
+
+**qortex-online** handles the real-time path from conversation text to knowledge graph nodes and edges. While `qortex-ingest` handles batch document ingestion with LLM extraction, `qortex-online` handles the live session path: chunking messages as they arrive, extracting named concepts locally, and wiring them into the graph with typed relationships.
+
+### Phase 1: Chunking
+
+`SentenceBoundaryChunker` splits text on sentence boundaries (regex `[.!?\n]`), using a 1 token = 4 chars approximation. Each chunk gets a deterministic SHA256 ID for deduplication across sessions.
+
+```python
+from qortex.online import default_chunker, Chunk
+
+chunks: list[Chunk] = default_chunker(
+    text="Long conversation...",
+    max_tokens=256,       # ~1024 chars per chunk
+    overlap_tokens=32,    # 128-char overlap for context
+    source_id="session-1",
+)
+```
+
+### Phase 2: Concept Extraction
+
+Three pluggable strategies, selected via `QORTEX_EXTRACTION` env var:
+
+| Strategy | Env Value | Speed | Cost | Features |
+|----------|-----------|-------|------|----------|
+| `SpaCyExtractor` | `spacy` (default) | Fast | Free | NER entities + noun chunks + dep-parse relations |
+| `LLMExtractor` | `llm` | Slow | API cost | Full Anthropic/Ollama extraction via qortex-ingest |
+| `NullExtractor` | `none` | Instant | Free | No-op, pipeline uses raw text only |
+
+#### SpaCy Extraction Pipeline
+
+The default `SpaCyExtractor` runs four sub-steps, each with its own OpenTelemetry span:
+
+1. **NLP Processing** (`extraction.spacy.nlp_process`) -- Run the spaCy `en_core_web_sm` pipeline
+2. **Entity Extraction** (`extraction.spacy.extract_entities`) -- Pull NER entities (PERSON, ORG, PRODUCT, GPE, WORK_OF_ART, EVENT, FAC, LAW, LANGUAGE, NORP)
+3. **Noun Chunk Extraction** (`extraction.spacy.extract_noun_chunks`) -- Collect noun phrases, filtering pronouns and determiners
+4. **Deduplication** (`extraction.spacy.deduplicate`) -- Merge entities and noun chunks, preferring NER on span overlap
+5. **Relation Inference** (`extraction.spacy.infer_relations`) -- Dependency-parse verb patterns and coordination
+
+### Phase 3: Relation Inference
+
+Relations are inferred from dependency parse patterns:
+
+| Verb Pattern | Relation Type |
+|-------------|---------------|
+| use, utilize, call, invoke | `USES` |
+| require, need, depend, import | `REQUIRES` |
+| contain, include, have, hold | `CONTAINS` |
+| implement, extend, inherit | `IMPLEMENTS` |
+| refine, specialize, customize | `REFINES` |
+| "X and Y" coordination | `SIMILAR_TO` |
+
+## Pluggable Strategies
+
+Both chunking and extraction follow the protocol pattern. Any callable matching the signature works:
+
+```python
+from qortex.online import ChunkingStrategy, ExtractionStrategy, Chunk, ExtractionResult
+
+# Custom chunker (e.g. tiktoken-based)
+class TiktokenChunker:
+    def __call__(
+        self, text: str, max_tokens: int = 256,
+        overlap_tokens: int = 32, source_id: str = "",
+    ) -> list[Chunk]:
+        ...
+
+# Custom extractor (e.g. OpenAI function calling)
+class OpenAIExtractor:
+    def __call__(self, text: str, domain: str = "") -> ExtractionResult:
+        ...
+```
+
+## Observability
+
+Every extraction step emits OpenTelemetry spans visible in Jaeger:
+
+```
+extraction.spacy                    [total time]
+  extraction.spacy.nlp_process      [spaCy pipeline]
+  extraction.spacy.extract_entities [NER pass]
+  extraction.spacy.extract_noun_chunks [noun chunks]
+  extraction.spacy.deduplicate      [span merging]
+  extraction.spacy.infer_relations  [dep-parse]
+```
+
+When `QORTEX_OTEL_ENABLED=true`, these spans are exported alongside the parent `online_index_pipeline` span from the MCP server.
+
+## Configuration
+
+| Env Var | Default | Purpose |
+|---------|---------|---------|
+| `QORTEX_EXTRACTION` | `spacy` | Extraction strategy: `spacy`, `llm`, `none` |
+| `QORTEX_OTEL_ENABLED` | `false` | Enable OpenTelemetry span export |
+
+## Data Types
+
+```python
+@dataclass(frozen=True)
+class Chunk:
+    id: str       # SHA256[:16] deterministic hash
+    text: str     # Chunk content
+    index: int    # Position in sequence
+
+@dataclass(frozen=True)
+class ExtractedConcept:
+    name: str           # e.g. "JWT Tokens"
+    description: str    # One-sentence context
+    confidence: float   # 0.9 (NER), 0.7 (noun chunk)
+
+@dataclass(frozen=True)
+class ExtractedRelation:
+    source_name: str     # Source concept name
+    target_name: str     # Target concept name
+    relation_type: str   # Maps to RelationType enum
+    confidence: float    # 0.5-0.8 depending on signal
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    concepts: list[ExtractedConcept]
+    relations: list[ExtractedRelation]
+```
+
+## Requirements
+
+- Python 3.11+
+- [spaCy](https://spacy.io/) 3.7+ with `en_core_web_sm` (optional, for SpaCy extraction)
+- `qortex-observe` (optional, for OpenTelemetry span tracing)
+- `qortex-ingest` (optional, for LLM extraction backend)
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Rewrites the qortex-online README from a minimal 11-line stub to full package documentation with inline SVG architecture diagram
- Updates the online-indexing guide with extraction pipeline details (per-chunk processing, concept nodes, relation edges)
- Adds Online Indexing to the mkdocs nav under Guides

## Test plan
- [ ] Verify SVG renders correctly on GitHub
- [ ] Verify mkdocs builds with `mkdocs build`
- [ ] Bragi gauntlet: clean pass (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)