### PR TITLE
docs: add sub-package pages to mkdocs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+      - "packages/*/README.md"
       - "mkdocs.yml"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
@@ -30,6 +31,13 @@ jobs:
 
       - name: Install mkdocs dependencies
         run: pip install mkdocs pymdown-extensions
+
+      - name: Sync package READMEs into docs
+        run: |
+          mkdir -p docs/packages
+          cp packages/qortex-online/README.md docs/packages/online.md
+          cp packages/qortex-observe/README.md docs/packages/observe.md
+          cp packages/qortex-ingest/README.md docs/packages/ingest.md
 
       - name: Build docs
         run: mkdocs build --strict

--- a/docs/packages/ingest.md
+++ b/docs/packages/ingest.md
@@ -1,0 +1,189 @@
+# qortex-ingest
+
+Pluggable document ingestion for [qortex](https://github.com/Peleke/qortex): extract concepts, relations, and rules from any source into a knowledge graph.
+
+<div align="center">
+
+<!-- Architecture: Ingestion Pipeline -->
+<svg viewBox="0 0 620 420" xmlns="http://www.w3.org/2000/svg" aria-label="qortex-ingest architecture: sources flow through chunking, extraction, and assembly into an ingestion manifest">
+  <style>
+    .ing-bg { fill: #0d1117; }
+    .ing-box { fill: #161b22; stroke: #30363d; stroke-width: 1; rx: 6; }
+    .ing-box-accent { fill: #161b22; stroke: #6366f1; stroke-width: 1.5; rx: 6; filter: url(#ing-glow); }
+    .ing-label { font-family: 'JetBrains Mono', monospace; font-size: 8px; fill: #8b949e; text-transform: uppercase; letter-spacing: 0.05em; }
+    .ing-title { font-family: system-ui, sans-serif; font-size: 13px; fill: #e6edf3; }
+    .ing-subtitle { font-family: system-ui, sans-serif; font-size: 10px; fill: #8b949e; }
+    .ing-flow { stroke: #6366f1; stroke-width: 1.2; stroke-dasharray: 4 3; fill: none; opacity: 0.5; }
+    .ing-flow-anim { animation: ing-dash 2s linear infinite; }
+    @keyframes ing-dash { to { stroke-dashoffset: -14; } }
+    .ing-arrow { fill: #6366f1; opacity: 0.5; }
+  </style>
+  <defs>
+    <filter id="ing-glow"><feGaussianBlur stdDeviation="2" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>
+  <rect width="620" height="420" class="ing-bg"/>
+
+  <!-- Sources row -->
+  <rect x="20" y="20" width="120" height="50" class="ing-box"/>
+  <text x="35" y="38" class="ing-label">text</text>
+  <text x="35" y="55" class="ing-title">TextIngestor</text>
+
+  <rect x="160" y="20" width="130" height="50" class="ing-box"/>
+  <text x="175" y="38" class="ing-label">markdown</text>
+  <text x="175" y="55" class="ing-title">MarkdownIngestor</text>
+
+  <rect x="310" y="20" width="130" height="50" class="ing-box"/>
+  <text x="325" y="38" class="ing-label">online</text>
+  <text x="325" y="55" class="ing-title">SentenceChunker</text>
+
+  <rect x="460" y="20" width="140" height="50" class="ing-box"/>
+  <text x="475" y="38" class="ing-label">custom</text>
+  <text x="475" y="55" class="ing-title">ChunkingStrategy</text>
+
+  <!-- Chunking -->
+  <rect x="180" y="120" width="260" height="50" class="ing-box"/>
+  <text x="195" y="138" class="ing-label">phase 1 · chunking</text>
+  <text x="195" y="157" class="ing-title">Format-specific → Chunk[]</text>
+
+  <!-- Flow: sources → chunking -->
+  <line x1="80" y1="70" x2="250" y2="120" class="ing-flow ing-flow-anim"/>
+  <line x1="225" y1="70" x2="290" y2="120" class="ing-flow ing-flow-anim"/>
+  <line x1="375" y1="70" x2="340" y2="120" class="ing-flow ing-flow-anim"/>
+  <line x1="530" y1="70" x2="380" y2="120" class="ing-flow ing-flow-anim"/>
+
+  <!-- Extraction -->
+  <rect x="180" y="220" width="260" height="65" class="ing-box-accent"/>
+  <text x="195" y="238" class="ing-label">phase 2 · extraction</text>
+  <text x="195" y="258" class="ing-title">LLM Backend (pluggable)</text>
+  <text x="195" y="274" class="ing-subtitle">Anthropic / Ollama / Stub</text>
+
+  <!-- Flow: chunking → extraction -->
+  <line x1="310" y1="170" x2="310" y2="220" class="ing-flow ing-flow-anim"/>
+  <polygon points="310,218 306,210 314,210" class="ing-arrow"/>
+
+  <!-- Manifest -->
+  <rect x="180" y="335" width="260" height="60" class="ing-box-accent"/>
+  <text x="195" y="353" class="ing-label">output</text>
+  <text x="195" y="373" class="ing-title">IngestionManifest</text>
+
+  <!-- Flow: extraction → manifest -->
+  <line x1="310" y1="285" x2="310" y2="335" class="ing-flow ing-flow-anim"/>
+  <polygon points="310,333 306,325 314,325" class="ing-arrow"/>
+
+  <!-- Manifest contents (side annotations) -->
+  <text x="460" y="345" class="ing-subtitle">ConceptNode[]</text>
+  <text x="460" y="360" class="ing-subtitle">ConceptEdge[]</text>
+  <text x="460" y="375" class="ing-subtitle">ExplicitRule[]</text>
+  <text x="460" y="390" class="ing-subtitle">CodeExample[]</text>
+
+  <!-- Extraction details (side annotations) -->
+  <text x="20" y="235" class="ing-subtitle">Pass 1: concepts</text>
+  <text x="20" y="250" class="ing-subtitle">Pass 2: reconcile</text>
+  <text x="20" y="265" class="ing-subtitle">Relations (10 types)</text>
+  <text x="20" y="280" class="ing-subtitle">Rules + examples</text>
+</svg>
+
+</div>
+
+## Install
+
+```bash
+pip install qortex-ingest
+```
+
+With extraction backends:
+
+```bash
+pip install "qortex-ingest[anthropic]"   # Claude API extraction
+pip install "qortex-ingest[pdf]"         # PDF support (pymupdf + pdfplumber)
+pip install "qortex-ingest[all]"         # everything
+```
+
+## Quick Start
+
+```python
+from qortex.ingest import IngestionManifest
+from qortex.ingest.text import TextIngestor
+from qortex.ingest.backends import get_extraction_backend
+
+# Auto-detect best available backend (Anthropic > Ollama > Stub)
+backend = get_extraction_backend()
+
+ingestor = TextIngestor(backend=backend)
+manifest: IngestionManifest = ingestor.ingest(
+    source_path="notes.txt",
+    domain="my-project",
+)
+
+print(f"Extracted {len(manifest.concepts)} concepts, {len(manifest.edges)} relations")
+```
+
+## What It Does
+
+**qortex-ingest** converts documents into structured knowledge graph components:
+
+1. **Chunk** — Split source by format (paragraphs, headings, sentences)
+2. **Extract** — Two-pass LLM extraction: generalizable concepts, then illustrative examples reconciled onto parents
+3. **Relate** — 10 relation types: `REQUIRES`, `USES`, `REFINES`, `IMPLEMENTS`, `PART_OF`, `SIMILAR_TO`, `ALTERNATIVE_TO`, `SUPPORTS`, `CHALLENGES`, `CONTRADICTS`
+4. **Assemble** — Output a single `IngestionManifest` (the universal contract)
+
+## Ingestors
+
+| Ingestor | Format | Chunking Strategy |
+|----------|--------|-------------------|
+| `TextIngestor` | Plain text | Fixed-size with configurable overlap |
+| `MarkdownIngestor` | Markdown | By heading hierarchy, preserves structure |
+| `SentenceBoundaryChunker` | Online/streaming | Regex sentence boundaries, SHA256 IDs |
+
+## Pluggable Chunkers
+
+Any callable matching `ChunkingStrategy` can replace the default:
+
+```python
+from qortex.online.chunker import Chunk
+
+def my_chunker(
+    text: str,
+    max_tokens: int = 256,
+    overlap_tokens: int = 32,
+    source_id: str = "",
+) -> list[Chunk]:
+    # Your custom chunking logic (tiktoken, semantic, etc.)
+    ...
+```
+
+## Extraction Backends
+
+| Backend | Cost | Features |
+|---------|------|----------|
+| `AnthropicExtractionBackend` | ~$0.60/57KB | Full extraction: concepts, relations, rules, code examples |
+| `OllamaExtractionBackend` | Free (local) | Concepts, relations, rules (no code examples) |
+| `StubLLMBackend` | Free | Testing only — returns configured fixtures |
+
+Auto-detection priority: Anthropic (if `ANTHROPIC_API_KEY` set) > Ollama (if reachable) > Stub.
+
+## Output: IngestionManifest
+
+The manifest is the universal contract between ingestion and the knowledge graph:
+
+```python
+@dataclass
+class IngestionManifest:
+    source: SourceMetadata        # origin info + stats
+    domain: str                   # knowledge domain name
+    concepts: list[ConceptNode]   # extracted concepts with embeddings
+    edges: list[ConceptEdge]      # typed relations between concepts
+    rules: list[ExplicitRule]     # best practices, warnings, principles
+    code_examples: list[CodeExample]  # linked to concepts and rules
+```
+
+## Requirements
+
+- Python 3.11+
+- `qortex` (for core models — `IngestionManifest`, `ConceptNode`, etc.)
+- `anthropic` (optional, for Claude extraction)
+- `pymupdf` + `pdfplumber` (optional, for PDF support)
+
+## License
+
+MIT

--- a/docs/packages/observe.md
+++ b/docs/packages/observe.md
@@ -1,0 +1,250 @@
+# qortex-observe
+
+Event-driven observability for [qortex](https://github.com/Peleke/qortex): metrics, traces, logs, and alerts.
+
+<div align="center">
+
+<!-- Architecture: Event-Driven Observability Pipeline -->
+<svg viewBox="0 0 620 520" xmlns="http://www.w3.org/2000/svg" aria-label="qortex-observe architecture: events flow through subscribers to metrics, traces, logs, and alerts">
+  <style>
+    .obs-bg { fill: #0d1117; }
+    .obs-box { fill: #161b22; stroke: #30363d; stroke-width: 1; rx: 6; }
+    .obs-box-accent { fill: #161b22; stroke: #6366f1; stroke-width: 1.5; rx: 6; filter: url(#obs-glow); }
+    .obs-label { font-family: 'JetBrains Mono', monospace; font-size: 8px; fill: #8b949e; text-transform: uppercase; letter-spacing: 0.05em; }
+    .obs-title { font-family: system-ui, sans-serif; font-size: 13px; fill: #e6edf3; }
+    .obs-subtitle { font-family: system-ui, sans-serif; font-size: 10px; fill: #8b949e; }
+    .obs-flow { stroke: #6366f1; stroke-width: 1.2; stroke-dasharray: 4 3; fill: none; opacity: 0.5; }
+    .obs-flow-anim { animation: obs-dash 2s linear infinite; }
+    @keyframes obs-dash { to { stroke-dashoffset: -14; } }
+    .obs-arrow { fill: #6366f1; opacity: 0.5; }
+  </style>
+  <defs>
+    <filter id="obs-glow"><feGaussianBlur stdDeviation="2" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>
+  <rect width="620" height="520" class="obs-bg"/>
+
+  <!-- Modules (top) -->
+  <rect x="180" y="20" width="260" height="50" class="obs-box"/>
+  <text x="195" y="38" class="obs-label">application code</text>
+  <text x="195" y="55" class="obs-title">emit(QueryCompleted(...))</text>
+
+  <!-- Event Bus -->
+  <rect x="180" y="110" width="260" height="50" class="obs-box-accent"/>
+  <text x="195" y="128" class="obs-label">event bus</text>
+  <text x="195" y="145" class="obs-title">QortexEventLinker (pyventus)</text>
+
+  <!-- Flow: modules → bus -->
+  <line x1="310" y1="70" x2="310" y2="110" class="obs-flow obs-flow-anim"/>
+  <polygon points="310,108 306,100 314,100" class="obs-arrow"/>
+
+  <!-- Subscriber row -->
+  <!-- Metrics -->
+  <rect x="20" y="210" width="130" height="70" class="obs-box"/>
+  <text x="35" y="228" class="obs-label">metrics</text>
+  <text x="35" y="248" class="obs-title">48 MetricDefs</text>
+  <text x="35" y="264" class="obs-subtitle">OTel SDK instruments</text>
+
+  <!-- Traces -->
+  <rect x="170" y="210" width="130" height="70" class="obs-box"/>
+  <text x="185" y="228" class="obs-label">traces</text>
+  <text x="185" y="248" class="obs-title">@traced spans</text>
+  <text x="185" y="264" class="obs-subtitle">selective export</text>
+
+  <!-- Logs -->
+  <rect x="320" y="210" width="130" height="70" class="obs-box"/>
+  <text x="335" y="228" class="obs-label">logs</text>
+  <text x="335" y="248" class="obs-title">structlog</text>
+  <text x="335" y="264" class="obs-subtitle">formatter × destination</text>
+
+  <!-- Alerts -->
+  <rect x="470" y="210" width="130" height="70" class="obs-box"/>
+  <text x="485" y="228" class="obs-label">alerts</text>
+  <text x="485" y="248" class="obs-title">rule engine</text>
+  <text x="485" y="264" class="obs-subtitle">cooldown + sinks</text>
+
+  <!-- Flow: bus → subscribers -->
+  <line x1="230" y1="160" x2="85" y2="210" class="obs-flow obs-flow-anim"/>
+  <line x1="280" y1="160" x2="235" y2="210" class="obs-flow obs-flow-anim"/>
+  <line x1="340" y1="160" x2="385" y2="210" class="obs-flow obs-flow-anim"/>
+  <line x1="390" y1="160" x2="535" y2="210" class="obs-flow obs-flow-anim"/>
+
+  <!-- Exporter row -->
+  <!-- OTLP -->
+  <rect x="20" y="330" width="130" height="55" class="obs-box"/>
+  <text x="35" y="348" class="obs-label">otlp push</text>
+  <text x="35" y="366" class="obs-subtitle">gRPC / HTTP protobuf</text>
+
+  <!-- Prometheus -->
+  <rect x="170" y="330" width="130" height="55" class="obs-box"/>
+  <text x="185" y="348" class="obs-label">prometheus pull</text>
+  <text x="185" y="366" class="obs-subtitle">:9464/metrics</text>
+
+  <!-- VictoriaLogs -->
+  <rect x="320" y="330" width="130" height="55" class="obs-box"/>
+  <text x="335" y="348" class="obs-label">victorialogs</text>
+  <text x="335" y="366" class="obs-subtitle">batched HTTP POST</text>
+
+  <!-- JSONL -->
+  <rect x="470" y="330" width="130" height="55" class="obs-box"/>
+  <text x="485" y="348" class="obs-label">jsonl file</text>
+  <text x="485" y="366" class="obs-subtitle">Loki-ready</text>
+
+  <!-- Flow: subscribers → exporters -->
+  <line x1="85" y1="280" x2="85" y2="330" class="obs-flow obs-flow-anim"/>
+  <line x1="85" y1="280" x2="235" y2="330" class="obs-flow obs-flow-anim"/>
+  <line x1="235" y1="280" x2="85" y2="330" class="obs-flow obs-flow-anim"/>
+  <line x1="385" y1="280" x2="385" y2="330" class="obs-flow obs-flow-anim"/>
+  <line x1="385" y1="280" x2="535" y2="330" class="obs-flow obs-flow-anim"/>
+
+  <!-- Grafana (bottom center) -->
+  <rect x="180" y="435" width="260" height="55" class="obs-box-accent"/>
+  <text x="195" y="453" class="obs-label">visualization</text>
+  <text x="195" y="472" class="obs-title">Grafana dashboards</text>
+
+  <!-- Flow: exporters → Grafana -->
+  <line x1="85" y1="385" x2="240" y2="435" class="obs-flow obs-flow-anim"/>
+  <line x1="235" y1="385" x2="290" y2="435" class="obs-flow obs-flow-anim"/>
+  <line x1="385" y1="385" x2="340" y2="435" class="obs-flow obs-flow-anim"/>
+
+  <!-- Carbon badge (side) -->
+  <rect x="470" y="435" width="130" height="55" class="obs-box"/>
+  <text x="485" y="453" class="obs-label">carbon accounting</text>
+  <text x="485" y="472" class="obs-subtitle">GHG / CDP / TCFD</text>
+</svg>
+
+</div>
+
+## Install
+
+```bash
+pip install qortex-observe
+```
+
+With OpenTelemetry exporters:
+
+```bash
+pip install "qortex-observe[otel]"
+```
+
+## Quick Start
+
+```python
+from qortex.observe import configure, emit
+from qortex.observe.events import QueryCompleted
+
+# Zero-config: structured logging to stderr
+configure()
+
+# Emit typed events — subscribers handle metrics, traces, logs
+emit(QueryCompleted(
+    query_id="q-1",
+    latency_ms=142.5,
+    seed_count=12,
+    result_count=8,
+    mode="hybrid",
+))
+```
+
+## What It Does
+
+**qortex-observe** decouples event emission from observation. Application code emits typed events; pluggable subscribers route them to metrics, traces, logs, and alerts — without modules knowing about any of those concerns.
+
+### Metrics (48 instruments)
+
+Single source of truth via the `METRICS` schema tuple. Counters, histograms, and gauges covering:
+
+| Domain | Metrics | Examples |
+|--------|---------|---------|
+| Query lifecycle | 4 | `qortex_queries`, `qortex_query_duration_seconds` |
+| PPR convergence | 2 | `qortex_ppr_started`, `qortex_ppr_iterations` |
+| Teleportation factors | 4 | `qortex_factor_updates`, `qortex_factor_entropy` |
+| Edge promotion | 5 | `qortex_edges_promoted`, `qortex_kg_coverage` |
+| Vector search | 8 | `qortex_vec_search_duration_seconds`, `qortex_vec_index_size` |
+| Online indexing | 4 | `qortex_messages_ingested`, `qortex_message_ingest_duration_seconds` |
+| Learning (bandit) | 7 | `qortex_learning_selections`, `qortex_learning_posterior_mean` |
+| Enrichment | 3 | `qortex_enrichment`, `qortex_enrichment_duration_seconds` |
+| Credit propagation | 4 | `qortex_credit_propagations`, `qortex_credit_alpha_delta` |
+| Carbon | 4 | `qortex_carbon_co2_grams`, `qortex_carbon_tokens` |
+
+### Traces
+
+The `@traced` decorator creates OpenTelemetry spans with overhead timing (wall time minus external I/O). `SelectiveSpanProcessor` exports only error spans, slow spans, or sampled spans — keeping telemetry volume manageable.
+
+```python
+from qortex.observe import traced
+
+@traced("retrieval.query")
+def retrieve(query: str) -> list[dict]:
+    results = vec_search(query)   # external call tracked separately
+    return rerank(results)        # compute overhead measured
+```
+
+### MCP Trace Propagation
+
+Distributed tracing across the Python server ↔ TypeScript client boundary via W3C `traceparent` in MCP `_meta`:
+
+```python
+from qortex.observe.mcp import mcp_trace_middleware
+
+result = mcp_trace_middleware("retrieve", params, handler)
+# Creates span "mcp.tool.retrieve" linked to client's trace context
+```
+
+### Logging (Swappable Formatter x Destination)
+
+Structured logging with a strategy pattern: pick a **formatter** (structlog or stdlib) and a **destination** (stderr, VictoriaLogs, JSONL file). All combinations work.
+
+### Carbon Accounting
+
+Per-inference CO2 and water tracking with regulatory export formats:
+
+```python
+from qortex.observe.carbon import calculate_carbon, calculate_equivalents
+
+calc = calculate_carbon(input_tokens=1000, output_tokens=500, provider="anthropic", model="claude-sonnet")
+equiv = calculate_equivalents(calc.total_co2_grams)
+# GHG Protocol, CDP, TCFD, ISO 14064-1 exports available
+```
+
+## Configuration
+
+All settings are environment-variable driven with safe defaults:
+
+| Env Var | Default | Purpose |
+|---------|---------|---------|
+| `QORTEX_LOG_FORMATTER` | `structlog` | `structlog` or `stdlib` |
+| `QORTEX_LOG_DESTINATION` | `stderr` | `stderr`, `victorialogs`, `jsonl` |
+| `QORTEX_LOG_LEVEL` | `INFO` | Python logging level |
+| `QORTEX_LOG_FORMAT` | `json` | `json` or `console` |
+| `QORTEX_OTEL_ENABLED` | `false` | Enable OTLP metric/trace push |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | OTLP collector endpoint |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | `grpc` or `http/protobuf` |
+| `QORTEX_PROMETHEUS_ENABLED` | `false` | Enable Prometheus `/metrics` |
+| `QORTEX_PROMETHEUS_PORT` | `9464` | Prometheus scrape port |
+| `QORTEX_OTEL_TRACE_SAMPLE_RATE` | `0.1` | Non-error/slow span sample rate |
+| `QORTEX_OTEL_TRACE_LATENCY_THRESHOLD_MS` | `100` | Always export slower spans |
+| `QORTEX_ALERTS_ENABLED` | `false` | Enable alert rule evaluation |
+
+## 40+ Typed Events
+
+All events are frozen dataclasses grouped by domain:
+
+- **Query**: `QueryStarted`, `QueryCompleted`, `QueryFailed`
+- **PPR**: `PPRStarted`, `PPRConverged`, `PPRDiverged`
+- **Factors**: `FactorUpdated`, `FactorsPersisted`, `FactorsLoaded`, `FactorDriftSnapshot`
+- **Edges**: `OnlineEdgeRecorded`, `EdgePromoted`, `BufferFlushed`
+- **Retrieval**: `VecSearchCompleted`, `OnlineEdgesGenerated`, `FeedbackReceived`
+- **Online Indexing**: `MessageIngested`, `ToolResultIngested`
+- **Learning**: `LearningSelectionMade`, `LearningObservationRecorded`, `LearningPosteriorUpdated`
+- **Carbon**: `CarbonTracked`
+
+## Requirements
+
+- Python 3.11+
+- [pyventus](https://pypi.org/project/pyventus/) (event bus)
+- [structlog](https://pypi.org/project/structlog/) (structured logging)
+- OpenTelemetry SDK (optional, for metrics/traces export)
+
+## License
+
+MIT

--- a/docs/packages/online.md
+++ b/docs/packages/online.md
@@ -1,0 +1,255 @@
+# qortex-online
+
+Online session indexing for [qortex](https://github.com/Peleke/qortex): chunking, concept extraction, and real-time graph wiring.
+
+<div align="center">
+
+<!-- Architecture: Online Extraction Pipeline -->
+<svg viewBox="0 0 620 480" xmlns="http://www.w3.org/2000/svg" aria-label="qortex-online architecture: conversation text flows through chunking, concept extraction, and relation inference into the knowledge graph">
+  <style>
+    .onl-bg { fill: #0d1117; }
+    .onl-box { fill: #161b22; stroke: #30363d; stroke-width: 1; rx: 6; }
+    .onl-box-accent { fill: #161b22; stroke: #6366f1; stroke-width: 1.5; rx: 6; filter: url(#onl-glow); }
+    .onl-label { font-family: 'JetBrains Mono', monospace; font-size: 8px; fill: #8b949e; text-transform: uppercase; letter-spacing: 0.05em; }
+    .onl-title { font-family: system-ui, sans-serif; font-size: 13px; fill: #e6edf3; }
+    .onl-subtitle { font-family: system-ui, sans-serif; font-size: 10px; fill: #8b949e; }
+    .onl-flow { stroke: #6366f1; stroke-width: 1.2; stroke-dasharray: 4 3; fill: none; opacity: 0.5; }
+    .onl-flow-anim { animation: onl-dash 2s linear infinite; }
+    @keyframes onl-dash { to { stroke-dashoffset: -14; } }
+    .onl-arrow { fill: #6366f1; opacity: 0.5; }
+  </style>
+  <defs>
+    <filter id="onl-glow"><feGaussianBlur stdDeviation="2" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>
+  <rect width="620" height="480" class="onl-bg"/>
+
+  <!-- Input -->
+  <rect x="180" y="20" width="260" height="50" class="onl-box"/>
+  <text x="195" y="38" class="onl-label">input</text>
+  <text x="195" y="55" class="onl-title">Conversation text (MCP session)</text>
+
+  <!-- Chunking -->
+  <rect x="180" y="110" width="260" height="55" class="onl-box"/>
+  <text x="195" y="128" class="onl-label">phase 1 · chunking</text>
+  <text x="195" y="148" class="onl-title">SentenceBoundaryChunker</text>
+
+  <!-- Flow: input → chunking -->
+  <line x1="310" y1="70" x2="310" y2="110" class="onl-flow onl-flow-anim"/>
+  <polygon points="310,108 306,100 314,100" class="onl-arrow"/>
+
+  <!-- Chunking annotations -->
+  <text x="460" y="125" class="onl-subtitle">256 tokens / chunk</text>
+  <text x="460" y="140" class="onl-subtitle">32-token overlap</text>
+  <text x="460" y="155" class="onl-subtitle">SHA256 deterministic IDs</text>
+
+  <!-- Extraction (accented) -->
+  <rect x="180" y="205" width="260" height="65" class="onl-box-accent"/>
+  <text x="195" y="223" class="onl-label">phase 2 · extraction</text>
+  <text x="195" y="243" class="onl-title">ExtractionStrategy (pluggable)</text>
+  <text x="195" y="259" class="onl-subtitle">SpaCy / LLM / Null</text>
+
+  <!-- Flow: chunking → extraction -->
+  <line x1="310" y1="165" x2="310" y2="205" class="onl-flow onl-flow-anim"/>
+  <polygon points="310,203 306,195 314,195" class="onl-arrow"/>
+
+  <!-- Extractor row -->
+  <rect x="20" y="205" width="140" height="65" class="onl-box"/>
+  <text x="35" y="223" class="onl-label">spacy (default)</text>
+  <text x="35" y="243" class="onl-title">NER + noun chunks</text>
+  <text x="35" y="259" class="onl-subtitle">dep-parse relations</text>
+
+  <rect x="460" y="205" width="140" height="65" class="onl-box"/>
+  <text x="475" y="223" class="onl-label">llm (opt-in)</text>
+  <text x="475" y="243" class="onl-title">Anthropic / Ollama</text>
+  <text x="475" y="259" class="onl-subtitle">via qortex-ingest</text>
+
+  <!-- Relation Inference -->
+  <rect x="180" y="310" width="260" height="55" class="onl-box"/>
+  <text x="195" y="328" class="onl-label">phase 3 · relation inference</text>
+  <text x="195" y="348" class="onl-title">Verb patterns + coordination</text>
+
+  <!-- Flow: extraction → relations -->
+  <line x1="310" y1="270" x2="310" y2="310" class="onl-flow onl-flow-anim"/>
+  <polygon points="310,308 306,300 314,300" class="onl-arrow"/>
+
+  <!-- Relation annotations -->
+  <text x="20" y="325" class="onl-subtitle">USES, REQUIRES, CONTAINS</text>
+  <text x="20" y="340" class="onl-subtitle">IMPLEMENTS, REFINES</text>
+  <text x="20" y="355" class="onl-subtitle">SIMILAR_TO (coordination)</text>
+
+  <!-- Output: Graph -->
+  <rect x="180" y="405" width="260" height="55" class="onl-box-accent"/>
+  <text x="195" y="423" class="onl-label">output</text>
+  <text x="195" y="443" class="onl-title">ConceptNode[] + ConceptEdge[]</text>
+
+  <!-- Flow: relations → graph -->
+  <line x1="310" y1="365" x2="310" y2="405" class="onl-flow onl-flow-anim"/>
+  <polygon points="310,403 306,395 314,395" class="onl-arrow"/>
+
+  <!-- Output annotations -->
+  <text x="460" y="420" class="onl-subtitle">CONTAINS (chunk → concept)</text>
+  <text x="460" y="435" class="onl-subtitle">Typed edges (dep-parse)</text>
+  <text x="460" y="450" class="onl-subtitle">SIMILAR_TO (co-occurrence)</text>
+</svg>
+
+</div>
+
+## Install
+
+```bash
+pip install qortex-online                # core (chunking + extraction protocol)
+pip install 'qortex-online[nlp]'         # + spaCy NER extraction
+pip install 'qortex-online[all]'         # everything
+```
+
+## Quick Start
+
+```python
+from qortex.online import default_chunker, SpaCyExtractor
+
+# Chunk conversation text
+chunks = default_chunker("User said JWT tokens expire after 30 minutes. The auth module validates them.")
+
+# Extract concepts and relations
+extractor = SpaCyExtractor()
+for chunk in chunks:
+    result = extractor(chunk.text, domain="auth")
+    for concept in result.concepts:
+        print(f"  {concept.name} ({concept.confidence:.1f})")
+    for rel in result.relations:
+        print(f"  {rel.source_name} --{rel.relation_type}--> {rel.target_name}")
+```
+
+## What It Does
+
+**qortex-online** handles the real-time path from conversation text to knowledge graph nodes and edges. While `qortex-ingest` handles batch document ingestion with LLM extraction, `qortex-online` handles the live session path: chunking messages as they arrive, extracting named concepts locally, and wiring them into the graph with typed relationships.
+
+### Phase 1: Chunking
+
+`SentenceBoundaryChunker` splits text on sentence boundaries (regex `[.!?\n]`), using a 1 token = 4 chars approximation. Each chunk gets a deterministic SHA256 ID for deduplication across sessions.
+
+```python
+from qortex.online import default_chunker, Chunk
+
+chunks: list[Chunk] = default_chunker(
+    text="Long conversation...",
+    max_tokens=256,       # ~1024 chars per chunk
+    overlap_tokens=32,    # 128-char overlap for context
+    source_id="session-1",
+)
+```
+
+### Phase 2: Concept Extraction
+
+Three pluggable strategies, selected via `QORTEX_EXTRACTION` env var:
+
+| Strategy | Env Value | Speed | Cost | Features |
+|----------|-----------|-------|------|----------|
+| `SpaCyExtractor` | `spacy` (default) | Fast | Free | NER entities + noun chunks + dep-parse relations |
+| `LLMExtractor` | `llm` | Slow | API cost | Full Anthropic/Ollama extraction via qortex-ingest |
+| `NullExtractor` | `none` | Instant | Free | No-op, pipeline uses raw text only |
+
+#### SpaCy Extraction Pipeline
+
+The default `SpaCyExtractor` runs four sub-steps, each with its own OpenTelemetry span:
+
+1. **NLP Processing** (`extraction.spacy.nlp_process`) -- Run the spaCy `en_core_web_sm` pipeline
+2. **Entity Extraction** (`extraction.spacy.extract_entities`) -- Pull NER entities (PERSON, ORG, PRODUCT, GPE, WORK_OF_ART, EVENT, FAC, LAW, LANGUAGE, NORP)
+3. **Noun Chunk Extraction** (`extraction.spacy.extract_noun_chunks`) -- Collect noun phrases, filtering pronouns and determiners
+4. **Deduplication** (`extraction.spacy.deduplicate`) -- Merge entities and noun chunks, preferring NER on span overlap
+5. **Relation Inference** (`extraction.spacy.infer_relations`) -- Dependency-parse verb patterns and coordination
+
+### Phase 3: Relation Inference
+
+Relations are inferred from dependency parse patterns:
+
+| Verb Pattern | Relation Type |
+|-------------|---------------|
+| use, utilize, call, invoke | `USES` |
+| require, need, depend, import | `REQUIRES` |
+| contain, include, have, hold | `CONTAINS` |
+| implement, extend, inherit | `IMPLEMENTS` |
+| refine, specialize, customize | `REFINES` |
+| "X and Y" coordination | `SIMILAR_TO` |
+
+## Pluggable Strategies
+
+Both chunking and extraction follow the protocol pattern. Any callable matching the signature works:
+
+```python
+from qortex.online import ChunkingStrategy, ExtractionStrategy, Chunk, ExtractionResult
+
+# Custom chunker (e.g. tiktoken-based)
+class TiktokenChunker:
+    def __call__(
+        self, text: str, max_tokens: int = 256,
+        overlap_tokens: int = 32, source_id: str = "",
+    ) -> list[Chunk]:
+        ...
+
+# Custom extractor (e.g. OpenAI function calling)
+class OpenAIExtractor:
+    def __call__(self, text: str, domain: str = "") -> ExtractionResult:
+        ...
+```
+
+## Observability
+
+Every extraction step emits OpenTelemetry spans visible in Jaeger:
+
+```
+extraction.spacy                    [total time]
+  extraction.spacy.nlp_process      [spaCy pipeline]
+  extraction.spacy.extract_entities [NER pass]
+  extraction.spacy.extract_noun_chunks [noun chunks]
+  extraction.spacy.deduplicate      [span merging]
+  extraction.spacy.infer_relations  [dep-parse]
+```
+
+When `QORTEX_OTEL_ENABLED=true`, these spans are exported alongside the parent `online_index_pipeline` span from the MCP server.
+
+## Configuration
+
+| Env Var | Default | Purpose |
+|---------|---------|---------|
+| `QORTEX_EXTRACTION` | `spacy` | Extraction strategy: `spacy`, `llm`, `none` |
+| `QORTEX_OTEL_ENABLED` | `false` | Enable OpenTelemetry span export |
+
+## Data Types
+
+```python
+@dataclass(frozen=True)
+class Chunk:
+    id: str       # SHA256[:16] deterministic hash
+    text: str     # Chunk content
+    index: int    # Position in sequence
+
+@dataclass(frozen=True)
+class ExtractedConcept:
+    name: str           # e.g. "JWT Tokens"
+    description: str    # One-sentence context
+    confidence: float   # 0.9 (NER), 0.7 (noun chunk)
+
+@dataclass(frozen=True)
+class ExtractedRelation:
+    source_name: str     # Source concept name
+    target_name: str     # Target concept name
+    relation_type: str   # Maps to RelationType enum
+    confidence: float    # 0.5-0.8 depending on signal
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    concepts: list[ExtractedConcept]
+    relations: list[ExtractedRelation]
+```
+
+## Requirements
+
+- Python 3.11+
+- [spaCy](https://spacy.io/) 3.7+ with `en_core_web_sm` (optional, for SpaCy extraction)
+- `qortex-observe` (optional, for OpenTelemetry span tracing)
+- `qortex-ingest` (optional, for LLM extraction backend)
+
+## License
+
+MIT

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,10 @@ nav:
     - CLI Commands: reference/cli.md
     - Data Models: reference/models.md
     - Interop Schema: reference/interop-schema.md
+  - Packages:
+    - qortex-online: packages/online.md
+    - qortex-observe: packages/observe.md
+    - qortex-ingest: packages/ingest.md
   - Architecture:
     - Overview: architecture/overview.md
     - Projection Pipeline: architecture/projection-pipeline.md


### PR DESCRIPTION
## Summary
- Adds a **Packages** section to the mkdocs nav with qortex-online, qortex-observe, and qortex-ingest
- Copies package READMEs (with SVG diagrams) into `docs/packages/` for mkdocs
- Updates docs CI to sync READMEs before build and trigger on `packages/*/README.md` changes

## Test plan
- [x] `mkdocs build --strict` passes locally
- [ ] GitHub Pages deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)