### PR TITLE
feat(tracing): instrument VecOnlyAdapter, ingestors, and LLM backends

### DIFF
--- a/packages/qortex-ingest/src/qortex/ingest/backends/anthropic.py
+++ b/packages/qortex-ingest/src/qortex/ingest/backends/anthropic.py
@@ -9,6 +9,17 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from qortex.core.models import ConceptNode
 
+try:
+    from qortex.observe.tracing import traced
+except ImportError:
+
+    def traced(name: str, *, external: bool = False):  # type: ignore[misc]
+        def _identity(fn):
+            return fn
+
+        return _identity
+
+
 # Lazy import to avoid hard dependency
 try:
     import anthropic
@@ -53,6 +64,7 @@ class AnthropicExtractionBackend:
         self.model = model or "claude-sonnet-4-20250514"
         self.max_concepts_per_call = max_concepts_per_call
 
+    @traced("llm.anthropic.call", external=True)
     def _call(self, system: str, user: str, max_tokens: int = 4096) -> str:
         """Make API call with rate limit retry."""
         import time

--- a/packages/qortex-ingest/src/qortex/ingest/backends/ollama.py
+++ b/packages/qortex-ingest/src/qortex/ingest/backends/ollama.py
@@ -12,6 +12,16 @@ from urllib.request import Request, urlopen
 if TYPE_CHECKING:
     from qortex.core.models import ConceptNode
 
+try:
+    from qortex.observe.tracing import traced
+except ImportError:
+
+    def traced(name: str, *, external: bool = False):  # type: ignore[misc]
+        def _identity(fn):
+            return fn
+
+        return _identity
+
 
 RELATION_TYPES = [
     "REQUIRES",
@@ -52,6 +62,7 @@ class OllamaExtractionBackend:
         except (URLError, TimeoutError, OSError):
             return False
 
+    @traced("llm.ollama.call", external=True)
     def _call(self, prompt: str) -> str:
         """Make API call to Ollama and return response."""
         payload = json.dumps(

--- a/packages/qortex-ingest/src/qortex/ingest/base.py
+++ b/packages/qortex-ingest/src/qortex/ingest/base.py
@@ -14,6 +14,19 @@ from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 if TYPE_CHECKING:
     from qortex.core.pruning import PruningConfig
 
+try:
+    from qortex.observe.tracing import traced
+except ImportError:
+
+    def traced(name: str, *, external: bool = False):  # type: ignore[misc]
+        """No-op decorator when qortex-observe is not installed."""
+
+        def _identity(fn):
+            return fn
+
+        return _identity
+
+
 from qortex.core.models import (
     CodeExample,
     ConceptEdge,
@@ -122,6 +135,7 @@ class Ingestor(ABC):
         """
         ...
 
+    @traced("ingest.pipeline")
     def ingest(
         self,
         source: Source,


### PR DESCRIPTION
## Summary

Closes #135

- **VecOnlyAdapter.retrieve()** — the default retrieval path had zero OTel spans. Added `@traced("retrieval.vec_only.query")` root span + extracted `_vec_search()` and `_resolve_nodes()` as traced helpers, mirroring the GraphRAGAdapter pattern
- **Ingestor.ingest()** — batch ingest pipeline was completely invisible. Added `@traced("ingest.pipeline")` root span
- **LLM backends** — Anthropic and Ollama `_call()` methods (the most expensive operations) now emit `@traced("llm.*.call", external=True)` spans, so LLM latency is tracked separately from overhead
- Graceful no-op fallback when `qortex-observe` is not installed (qortex-ingest has no hard dependency on it)

## Files changed

| File | Change |
|------|--------|
| `src/qortex/hippocampus/adapter.py` | `@traced` on VecOnlyAdapter + extracted traced helpers |
| `packages/qortex-ingest/src/qortex/ingest/base.py` | `@traced` on Ingestor.ingest() + graceful import |
| `packages/qortex-ingest/src/qortex/ingest/backends/anthropic.py` | `@traced(external=True)` on _call() |
| `packages/qortex-ingest/src/qortex/ingest/backends/ollama.py` | `@traced(external=True)` on _call() |

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration` — 2055 passed, 0 failures
- [x] Adapter + pipeline tests specifically: 278 passed
- [x] `ruff check` + `ruff format` clean
- [x] mypy: only pre-existing errors (unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)