### PR TITLE
docs: comprehensive learning layer documentation

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -92,7 +92,7 @@ rule = ExplicitRule(
 
 ### Derived Rules
 
-Rules generated from edges using templates. qortex has 30 built-in templates (3 variants × 10 relation types):
+Rules generated from edges using templates. qortex has 30 built-in templates (3 variants x 10 relation types):
 
 | Variant | Style | Example |
 |---------|-------|---------|
@@ -147,13 +147,100 @@ The MCP server also exposes a separate registry of **named vector indexes** (the
 
 ## Adaptive Learning
 
-qortex includes a Thompson Sampling-based learning module that improves retrieval quality over time.
+qortex includes a Thompson Sampling-based learning module that improves retrieval quality over time. This is the key differentiator: instead of returning the same results regardless of feedback, qortex models every candidate as a statistical belief and updates that belief from experience.
 
-- **Learner**: Manages a pool of "arms" (candidate items). Uses Beta-Bernoulli posteriors to balance exploration (trying new items) vs exploitation (using known-good items).
-- **LearningStore protocol**: Pluggable persistence for arm states. Two backends: `SqliteLearningStore` (ACID, concurrent-safe) and `JsonLearningStore` (simple, no locking).
-- **Credit propagation**: When feedback is recorded, credit can cascade through the causal DAG to update posteriors of upstream concepts.
+### What the Learning Layer Does
 
-The learning layer is exposed via MCP tools (`qortex_learning_select`, `qortex_learning_observe`, etc.) and the Python `Learner` API.
+The learning layer treats context engineering as a multi-armed bandit problem. Every candidate item that could appear in a prompt -- a retrieved concept, a tool, a file, a prompt component -- is an **arm**. The system's goal is to learn which arms produce good outcomes and select them more often, while still exploring uncertain alternatives.
+
+### Arms and Posteriors
+
+Each arm carries a Beta(alpha, beta) posterior distribution that encodes the system's belief about that arm's success probability.
+
+| Term | Meaning |
+|------|---------|
+| **Arm** | A candidate action: a concept to retrieve, a tool to invoke, a prompt fragment to include. Identified by a hierarchical ID like `"tool:search:v2"`. |
+| **ArmState** | The posterior belief: `alpha` (pseudo-successes), `beta` (pseudo-failures), `pulls` (observation count), `total_reward`. |
+| **Posterior mean** | `alpha / (alpha + beta)` -- the expected success rate. Starts at 0.5 (uniform prior) and shifts toward 0 or 1 with observations. |
+| **Token cost** | Each arm can declare its token cost, enabling budget-aware selection that fills the context window optimally. |
+
+A new arm starts with `Beta(1, 1)`, the uniform distribution -- maximum uncertainty. Every observation sharpens the belief.
+
+### Selection
+
+When qortex needs to choose which items to include in a prompt, it uses **Thompson Sampling**:
+
+1. For each candidate arm, sample a value from its `Beta(alpha, beta)` posterior.
+2. Rank candidates by sampled value (descending).
+3. Select the top-k, optionally respecting a token budget.
+
+Arms that are uncertain get sampled high sometimes and low sometimes -- this is how the system explores. Arms with strong track records get consistently high samples -- this is how it exploits.
+
+A `baseline_rate` (default 10%) forces uniform-random selection to guarantee ongoing exploration even after posteriors have converged. Arms below `min_pulls` are force-included regardless of their posterior to protect against cold-start bias.
+
+### Observation
+
+After the agent uses the selected context and the user provides feedback, the system records an observation:
+
+```python
+learner.observe(ArmOutcome(arm_id="concept:jwt_validation", reward=1.0, outcome="accepted"))
+```
+
+The reward model maps outcomes to floats:
+
+| Reward Model | accepted | partial | rejected |
+|-------------|----------|---------|----------|
+| `BinaryReward` | 1.0 | 0.0 | 0.0 |
+| `TernaryReward` | 1.0 | 0.5 | 0.0 |
+
+The posterior updates: `alpha += reward`, `beta += (1 - reward)`. This is the standard Beta-Bernoulli conjugate update -- exact, closed-form, and computationally trivial.
+
+### Credit Propagation Through the Causal DAG
+
+Feedback does not stop at the directly-used item. The `CreditAssigner` builds a causal DAG from the knowledge graph's typed edges and propagates credit backward to ancestor concepts.
+
+**How it works:**
+
+1. A rule linked to concepts `["jwt_validation", "auth_middleware"]` receives reward `+1.0`.
+2. Direct concepts receive full credit: `alpha_delta = +1.0`.
+3. The DAG is traversed upward. Each ancestor receives `credit * decay_factor * edge_weight`, where `decay_factor` defaults to 0.5 and `edge_weight` comes from the graph edge strength.
+4. Propagation stops when credit falls below `min_credit` (default 0.01) or `max_depth` (default 50) is reached.
+5. The resulting `alpha_delta` / `beta_delta` values are applied directly to each concept's posterior via `learner.apply_credit_deltas()`.
+
+This means accepting a result about "JWT Validation" also strengthens "Authentication" (via REFINES), "Security Middleware" (via PART_OF), and other upstream concepts proportional to their causal distance.
+
+### Connection to the Knowledge Graph
+
+The learning layer and the knowledge graph reinforce each other:
+
+- **Graph structure defines causal paths.** Typed edges (REQUIRES, REFINES, USES, etc.) determine how credit flows between concepts. A well-connected graph produces richer credit propagation.
+- **Learning updates bias retrieval.** Personalized PageRank scores are adjusted by posterior means, so concepts the system has learned to trust rank higher.
+- **Feedback closes the loop.** Every `qortex_feedback` call simultaneously updates the learning layer's posteriors and optionally propagates credit through the causal DAG.
+
+### Persistence
+
+Two backends store arm states:
+
+- **`SqliteLearningStore`** (default): ACID-safe, concurrent-safe with WAL mode and thread locking. File layout: `~/.qortex/learning/{learner_name}.db`.
+- **`JsonLearningStore`**: Simple JSON files, no locking. Suitable for single-process testing. File layout: `~/.qortex/learning/{learner_name}.json`.
+
+Both partition state by context hash, so the same arm can have different posteriors in different contexts (e.g., different task types).
+
+### MCP Tools
+
+The learning layer is fully accessible via MCP:
+
+| Tool | Purpose |
+|------|---------|
+| `qortex_learning_select` | Select arms from candidates using Thompson Sampling |
+| `qortex_learning_observe` | Record an outcome and update posteriors |
+| `qortex_learning_posteriors` | Inspect current posterior distributions |
+| `qortex_learning_metrics` | Get aggregate metrics (pulls, reward, accuracy) |
+| `qortex_learning_session_start` | Start a named session for tracking |
+| `qortex_learning_session_end` | End a session and get a summary |
+| `qortex_learning_reset` | Delete learned posteriors (full or scoped) |
+
+See the [Learning Layer Guide](../guides/learning.md) for configuration, observability, and intervention options.
 
 ## Observability (qortex-observe)
 

--- a/docs/guides/learning.md
+++ b/docs/guides/learning.md
@@ -1,0 +1,391 @@
+# Learning Layer Guide
+
+qortex uses Thompson Sampling to learn which retrieval candidates produce good outcomes. This guide covers configuration, observation, and intervention.
+
+For the conceptual overview, see [Adaptive Learning](../getting-started/concepts.md#adaptive-learning) in Core Concepts.
+
+## Overview
+
+The learning layer models context engineering as a multi-armed bandit problem. Each candidate item (a concept, tool, file, or prompt fragment) is an **arm** with a Beta-Bernoulli posterior distribution. The system selects arms by sampling from their posteriors, observes outcomes from user feedback, and updates posteriors accordingly. Over time, it converges on the candidates that work.
+
+The core loop is:
+
+1. **Select** -- sample from posteriors, pick the top-k arms (possibly within a token budget).
+2. **Use** -- the agent includes the selected items in its context.
+3. **Observe** -- the user provides feedback (accepted, rejected, partial).
+4. **Update** -- posteriors shift; credit propagates through the causal DAG.
+
+## Configuration
+
+The `LearnerConfig` dataclass controls all learning behavior:
+
+```python
+from qortex.learning import Learner, LearnerConfig
+
+config = LearnerConfig(
+    name="my-learner",       # Unique name; also used for state file naming
+    baseline_rate=0.1,       # Probability of forced uniform exploration (default 10%)
+    seed_boost=2.0,          # Alpha boost applied to seed arms on first use
+    seed_arms=[],            # Arm IDs that start with boosted priors
+    state_dir="",            # Override for state persistence path (default: ~/.qortex/learning/)
+    max_arms=1000,           # Cap on tracked arms
+    min_pulls=0,             # Force-include arms with fewer than N observations (cold-start protection)
+)
+
+learner = Learner(config)
+```
+
+### Configuration Reference
+
+| Parameter | Type | Default | Effect |
+|-----------|------|---------|--------|
+| `name` | `str` | (required) | Identifies the learner. Used as the state file name. |
+| `baseline_rate` | `float` | `0.1` | Probability of uniform-random exploration per selection. Higher values explore more, converge slower. |
+| `seed_boost` | `float` | `2.0` | Prior alpha for seed arms. A seed arm starts at `Beta(2.0, 1.0)` instead of `Beta(1, 1)`, biasing it toward selection. |
+| `seed_arms` | `list[str]` | `[]` | Arm IDs to boost. Only applied when the arm has zero pulls (first creation). |
+| `state_dir` | `str` | `""` | Custom directory for state files. Empty string uses `~/.qortex/learning/`. |
+| `max_arms` | `int` | `1000` | Maximum tracked arms. Prevents unbounded state growth. |
+| `min_pulls` | `int` | `0` | Arms with fewer than this many observations are force-included in every selection, bypassing Thompson Sampling. Useful for cold-start protection. |
+
+### Reward Models
+
+The reward model maps outcome strings to float rewards in `[0, 1]`:
+
+| Model | `accepted` | `partial` | `rejected` | Unknown |
+|-------|-----------|-----------|-----------| --------|
+| `BinaryReward` | 1.0 | 0.0 | 0.0 | 0.0 |
+| `TernaryReward` (default) | 1.0 | 0.5 | 0.0 | 0.0 |
+
+You can also bypass the reward model entirely by passing a `reward` float directly to `observe()`.
+
+### Strategy
+
+The default (and currently only) strategy is `ThompsonSampling`. It implements the `LearningStrategy` protocol:
+
+- **select()**: Samples from each arm's `Beta(alpha, beta)` posterior, ranks by sample, returns top-k within optional token budget.
+- **update()**: Applies `alpha += reward`, `beta += (1 - reward)` -- the Beta-Bernoulli conjugate update.
+
+Custom strategies can be plugged in by implementing the `LearningStrategy` protocol and passing them to the `Learner` constructor.
+
+### Persistence Backends
+
+| Backend | Install | Thread-safe | Use case |
+|---------|---------|-------------|----------|
+| `SqliteLearningStore` (default) | Built-in | Yes (WAL + thread lock) | Production, MCP server |
+| `JsonLearningStore` | Built-in | No | Testing, single-process scripts |
+
+Both backends partition state by a deterministic hash of the context dict, so the same arm can have independent posteriors across different task contexts.
+
+State files are stored at `{state_dir}/{learner_name}.db` (SQLite) or `{state_dir}/{learner_name}.json` (JSON).
+
+## Python API
+
+### Basic select-observe loop
+
+```python
+from qortex.learning import Learner, LearnerConfig, Arm, ArmOutcome
+
+learner = Learner(LearnerConfig(name="retrieval"))
+
+# Define candidates
+candidates = [
+    Arm(id="concept:jwt_validation", token_cost=120),
+    Arm(id="concept:auth_middleware", token_cost=200),
+    Arm(id="concept:password_hashing", token_cost=150),
+]
+
+# Select the best 2 within a token budget
+result = learner.select(candidates, context={"task": "security-review"}, k=2, token_budget=400)
+for arm in result.selected:
+    print(f"Selected: {arm.id} (score: {result.scores[arm.id]:.3f})")
+
+# After the agent uses these and gets feedback:
+learner.observe(ArmOutcome(arm_id="concept:jwt_validation", outcome="accepted", reward=1.0))
+learner.observe(ArmOutcome(arm_id="concept:auth_middleware", outcome="rejected", reward=0.0))
+```
+
+### Inspecting posteriors
+
+```python
+# All posteriors in a context
+posteriors = learner.posteriors(context={"task": "security-review"})
+for arm_id, state in posteriors.items():
+    print(f"{arm_id}: mean={state['mean']:.3f}, pulls={state['pulls']}")
+
+# Top arms by posterior mean
+for arm_id, state in learner.top_arms(k=5):
+    print(f"{arm_id}: mean={state.mean:.3f}")
+```
+
+### Aggregate metrics
+
+```python
+metrics = learner.metrics()
+# {
+#   "learner": "retrieval",
+#   "total_pulls": 47,
+#   "total_reward": 31.5,
+#   "accuracy": 0.6702,
+#   "arm_count": 12,
+#   "explore_ratio": 0.1,
+# }
+```
+
+### Credit propagation
+
+```python
+from qortex.causal.credit import CreditAssigner
+from qortex.causal.dag import CausalDAG
+
+# Build DAG from knowledge graph edges
+dag = CausalDAG.from_edges(edges)
+assigner = CreditAssigner(dag=dag, decay_factor=0.5, min_credit=0.01)
+
+# Assign credit when a rule linked to these concepts gets reward +1.0
+assignments = assigner.assign_credit(
+    rule_concept_ids=["jwt_validation", "auth_middleware"],
+    reward=1.0,
+)
+
+# Convert to posterior deltas and apply
+deltas = CreditAssigner.to_posterior_updates(assignments)
+learner.apply_credit_deltas(deltas, context={"task": "security-review"})
+```
+
+## MCP Tools
+
+All learning operations are available as MCP tools for use by any agent:
+
+### qortex_learning_select
+
+Select arms from a candidate pool using Thompson Sampling.
+
+```json
+{
+  "learner": "retrieval",
+  "candidates": [
+    {"id": "concept:jwt_validation", "token_cost": 120},
+    {"id": "concept:auth_middleware", "token_cost": 200}
+  ],
+  "k": 2,
+  "token_budget": 400
+}
+```
+
+### qortex_learning_observe
+
+Record an outcome for a selected arm.
+
+```json
+{
+  "learner": "retrieval",
+  "arm_id": "concept:jwt_validation",
+  "outcome": "accepted"
+}
+```
+
+### qortex_learning_posteriors
+
+Inspect current posterior distributions. Optionally filter by arm IDs.
+
+```json
+{
+  "learner": "retrieval",
+  "arm_ids": ["concept:jwt_validation", "concept:auth_middleware"]
+}
+```
+
+### qortex_learning_metrics
+
+Get aggregate learning metrics.
+
+```json
+{
+  "learner": "retrieval"
+}
+```
+
+### qortex_learning_reset
+
+Delete learned posteriors. Scoped by arm IDs and/or context.
+
+```json
+{
+  "learner": "retrieval",
+  "arm_ids": ["concept:password_hashing"],
+  "context": {"task": "security-review"}
+}
+```
+
+### qortex_learning_session_start / session_end
+
+Track a named learning session for audit and debugging.
+
+## Observing Learning Dynamics (Grafana)
+
+The learning layer emits three event types that flow through `qortex-observe` into Prometheus and the pre-built Grafana dashboard.
+
+### Events
+
+| Event | When | Key Fields |
+|-------|------|------------|
+| `LearningSelectionMade` | Every `select()` call | `learner`, `selected_count`, `excluded_count`, `is_baseline`, `token_budget`, `used_tokens` |
+| `LearningObservationRecorded` | Every `observe()` call | `learner`, `arm_id`, `reward`, `outcome`, `context_hash` |
+| `LearningPosteriorUpdated` | Every posterior change | `learner`, `arm_id`, `alpha`, `beta`, `pulls`, `mean` |
+| `CreditPropagated` | Every credit assignment | `query_id`, `concept_count`, `direct_count`, `ancestor_count`, `total_alpha_delta`, `total_beta_delta` |
+
+### Prometheus Metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `qortex_learning_selections_total` | Counter | `learner`, `baseline` |
+| `qortex_learning_observations_total` | Counter | `learner`, `outcome` |
+| `qortex_learning_posterior_mean` | Gauge | `learner`, `arm_id` |
+| `qortex_learning_token_budget_used` | Histogram | -- |
+| `qortex_credit_propagations_total` | Counter | `learner` |
+| `qortex_credit_concepts_per_propagation` | Histogram | -- |
+| `qortex_credit_alpha_delta_total` | Counter | -- |
+| `qortex_credit_beta_delta_total` | Counter | -- |
+
+### Grafana Dashboard Panels
+
+The `qortex-main` dashboard includes two sections for the learning layer:
+
+**Learning & Bandits:**
+
+- **Selection Rate** -- `rate(qortex_learning_selections_total[5m])` split by `baseline=true/false`. When posteriors converge, the Thompson Sampling line (`baseline=false`) should dominate.
+- **Observation Rate** -- `rate(qortex_learning_observations_total[5m])` split by `outcome`. In a converging system, `accepted` trends upward.
+- **Posterior Mean (top 10 arms)** -- `topk(10, qortex_learning_posterior_mean)`. This is the learning itself. Mean near 1.0 = confident success. All arms at 0.5 = insufficient data.
+- **Token Budget Usage** -- p50/p95 histograms of token budget utilization per selection.
+
+**Credit Propagation:**
+
+- **Credit Propagation Rate** -- propagations/sec through the causal DAG. Should track feedback rate. Zero while feedback flows means the feature flag is off or the DAG is empty.
+- **Concepts per Propagation** -- p50/p95 of how many concepts receive credit per event. 3-5 is typical for a well-connected DAG.
+- **Total Credit Propagations** -- lifetime count stat panel.
+
+### Starting the Observability Stack
+
+```bash
+cd docker && docker compose up -d
+
+# Open the dashboard
+open http://localhost:3010/d/qortex-main/qortex-observability
+```
+
+Credit propagation requires the feature flag: `QORTEX_CREDIT_PROPAGATION=on`.
+
+## Intervention: Tuning and Resetting
+
+### Decaying stale posteriors
+
+If source data changes and old learned signals are no longer valid, decay an arm's posterior toward the uniform prior:
+
+```python
+# Shrink alpha and beta by 10% (preserves mean ratio, weakens confidence)
+learner.decay_arm("concept:old_pattern", decay_factor=0.9)
+```
+
+This multiplies both `alpha` and `beta` by the decay factor, preserving the mean ratio while reducing confidence. Floors at 0.01 to prevent degenerate distributions.
+
+### Resetting specific arms
+
+Delete learned state entirely for specific arms or contexts:
+
+```python
+# Reset one arm in all contexts
+learner.reset(arm_ids=["concept:poisoned_data"])
+
+# Reset all arms in a specific context
+learner.reset(context={"task": "deprecated-workflow"})
+
+# Full reset -- all arms, all contexts
+count = learner.reset()
+print(f"Deleted {count} arm states")
+```
+
+Via MCP:
+
+```json
+{
+  "tool": "qortex_learning_reset",
+  "arguments": {
+    "learner": "retrieval",
+    "arm_ids": ["concept:poisoned_data"]
+  }
+}
+```
+
+### Boosting seed arms
+
+When introducing new arms you want the system to explore early, add them as seed arms:
+
+```python
+config = LearnerConfig(
+    name="retrieval",
+    seed_arms=["concept:new_pattern_v2"],
+    seed_boost=3.0,  # Start at Beta(3.0, 1.0) instead of Beta(1, 1)
+)
+```
+
+Seed boosts are applied only when the arm has zero pulls, so they are safe to leave in config permanently.
+
+### Adjusting exploration rate
+
+If the system is exploiting too aggressively (always picking the same arms) or exploring too much (not converging):
+
+```python
+# More exploration (useful early or when adding many new arms)
+config = LearnerConfig(name="retrieval", baseline_rate=0.2)
+
+# Less exploration (useful once posteriors are well-separated)
+config = LearnerConfig(name="retrieval", baseline_rate=0.05)
+```
+
+### Cold-start protection
+
+Force-include arms that have not been observed enough times:
+
+```python
+# Arms with fewer than 3 observations are always included
+config = LearnerConfig(name="retrieval", min_pulls=3)
+```
+
+This bypasses Thompson Sampling for under-observed arms, ensuring every arm gets a minimum number of trials before the system can choose to ignore it.
+
+## Architecture Summary
+
+```
+User Feedback
+    |
+    v
+RewardModel (outcome -> float)
+    |
+    v
+Learner.observe()
+    |
+    +---> ArmState update (alpha += r, beta += 1-r)
+    |         |
+    |         v
+    |     LearningStore (SQLite or JSON)
+    |
+    +---> CreditAssigner (causal DAG)
+              |
+              v
+          Ancestor posteriors updated (decayed credit)
+              |
+              v
+          Learner.apply_credit_deltas()
+              |
+              v
+          LearningStore (persist)
+
+All steps emit events -> qortex-observe -> Prometheus -> Grafana
+```
+
+## Next Steps
+
+- [Observability and Grafana Dashboard](observability.md) -- full metrics reference and dashboard panel guide
+- [Core Concepts: Adaptive Learning](../getting-started/concepts.md#adaptive-learning) -- conceptual overview
+- [Causal Reasoning tutorials](../tutorials/causal-dag/index.md) -- theory behind the causal DAG
+- [The Geometry of Learning](../tutorials/fisher-information/index.md) -- information-geometric perspective on posterior dynamics

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
     - Quick Start: getting-started/quickstart.md
     - Core Concepts: getting-started/concepts.md
   - Guides:
+    - Learning Layer: guides/learning.md
     - Querying the Graph: guides/querying.md
     - Projecting Rules: guides/projecting-rules.md
     - Rule Enrichment: guides/enrichment.md


### PR DESCRIPTION
## Summary
- Adds Learning Layer section to `docs/index.md` homepage explaining Thompson Sampling, credit propagation, and observability
- Expands `docs/getting-started/concepts.md` with full arms/posteriors/selection/observation reference and credit propagation through the causal DAG
- Creates new `docs/guides/learning.md` with configuration reference, Python API examples, MCP tools, Grafana dashboard panels, and intervention options (decay, reset, seed boost, exploration tuning)
- Adds learning guide to mkdocs nav

This is the key differentiator documentation that was severely under-documented. The learning layer is the core of what makes qortex different from static RAG.

## Test plan
- [ ] `mkdocs serve` renders all three modified/new pages
- [ ] Internal links resolve correctly
- [ ] No broken SVG references

🤖 Generated with [Claude Code](https://claude.com/claude-code)