### PR TITLE
docs: sync with Docker service deployment model

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,39 @@
 services:
+  # --- qortex application ---
+  # The qortex server with the embedding model baked into the image.
+  # Start with: docker compose up -d qortex
+  qortex:
+    image: ghcr.io/peleke/qortex:latest
+    container_name: qortex
+    ports:
+      - "8400:8400"   # REST API
+      - "8401:8401"   # MCP Streamable HTTP
+    environment:
+      QORTEX_STORE: ${QORTEX_STORE:-postgres}
+      DATABASE_URL: postgresql://qortex:qortex@postgres:5432/qortex
+      QORTEX_GRAPH: ${QORTEX_GRAPH:-memgraph}
+      MEMGRAPH_HOST: memgraph
+      MEMGRAPH_PORT: "7687"
+      MEMGRAPH_USER: ${MEMGRAPH_USER:-memgraph}
+      MEMGRAPH_PASSWORD: ${MEMGRAPH_PASSWORD:-memgraph}
+      QORTEX_EXTRACTION: ${QORTEX_EXTRACTION:-spacy}
+      QORTEX_OTEL_ENABLED: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+      QORTEX_PROMETHEUS_ENABLED: "true"
+      QORTEX_PROMETHEUS_PORT: "9464"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8400/v1/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
   # Memgraph + Lab: only needed for local-only dev (no sandbox).
   # When using the sandbox, Lima auto-forwards these ports from the VM.
   # Start with: docker compose --profile local-graph up -d
@@ -68,15 +103,17 @@ services:
     volumes:
       - ./otel-collector/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
     depends_on:
-      - jaeger
+      - tempo
 
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    container_name: qortex-jaeger
+  tempo:
+    image: grafana/tempo:2.7.2
+    container_name: qortex-tempo
     ports:
-      - "16686:16686" # Jaeger UI
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
+      - "3200:3200"   # Tempo HTTP API (query frontend)
+    volumes:
+      - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml
+      - tempo_data:/var/tempo
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
 
   prometheus:
     image: prom/prometheus:latest
@@ -111,10 +148,11 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-qortex}
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
-      - GF_INSTALL_PLUGINS=victoriametrics-logs-datasource,jdbranham-diagram-panel
+      - GF_INSTALL_PLUGINS=victoriametrics-logs-datasource,jdbranham-diagram-panel,grafana-tempo-datasource
     depends_on:
       - prometheus
       - victorialogs
+      - tempo
 
 volumes:
   postgres_data:
@@ -123,3 +161,4 @@ volumes:
   prometheus_data:
   victorialogs_data:
   grafana_data:
+  tempo_data:

--- a/docker/otel-collector/otel-collector-config.yaml
+++ b/docker/otel-collector/otel-collector-config.yaml
@@ -1,4 +1,4 @@
-# OpenTelemetry Collector config: receives OTLP, routes traces to Jaeger,
+# OpenTelemetry Collector config: receives OTLP, routes traces to Tempo,
 # exports metrics for Prometheus scraping.
 #
 # This enables push-based observability from remote environments (e.g. sandbox)
@@ -17,8 +17,8 @@ processors:
     timeout: 5s
 
 exporters:
-  otlp/jaeger:
-    endpoint: jaeger:4317
+  otlp/tempo:
+    endpoint: tempo:4317
     tls:
       insecure: true
 
@@ -32,7 +32,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/jaeger]
+      exporters: [otlp/tempo]
     metrics:
       receivers: [otlp]
       processors: [batch]

--- a/docker/tempo/tempo.yaml
+++ b/docker/tempo/tempo.yaml
@@ -1,0 +1,30 @@
+# Grafana Tempo configuration for qortex trace storage.
+# Receives OTLP traces from the OTel Collector.
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+    block:
+      bloom_filter_false_positive: 0.05
+
+metrics_generator:
+  storage:
+    path: /var/tempo/metrics
+  traces_storage:
+    path: /var/tempo/traces

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -56,13 +56,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Declarative metric schema**: All 36 metrics defined in a single `metrics_schema.py` registry with types, labels, and custom histogram buckets
 - **Unified metrics pipeline**: OTel as sole metric backend. One set of event handlers in `metrics_handlers.py` creates OTel instruments from the schema
 - **PrometheusMetricReader**: Replaces the old `prometheus_client` subscriber. Serves `/metrics` on port 9464 using OTel's built-in Prometheus exporter
-- **Full trace hierarchy**: `@traced` decorator on all MemgraphBackend operations (14 methods), vec layer (embeddings, index ops), and learning (select, observe, credit deltas). Jaeger shows complete parent-child span trees
+- **Full trace hierarchy**: `@traced` decorator on all MemgraphBackend operations (14 methods), vec layer (embeddings, index ops), and learning (select, observe, credit deltas). Tempo (via Grafana) shows complete parent-child span trees
 - **PPR span attributes**: `ppr.node_count`, `ppr.edge_count`, `ppr.iterations`, `ppr.converged`, `ppr.final_diff`, `ppr.latency_ms` on every PageRank execution
 - **Embedding model tracing**: `vec.embed.sentence_transformer`, `vec.embed.openai`, `vec.embed.ollama` spans with model name, batch size, and external I/O marking
 - **Cached embedding tracing**: `vec.embed.cached` spans with cache hit/miss/batch_size attributes
 - **Selective trace sampling**: `SelectiveSpanProcessor` always exports errors and slow spans; normal spans sampled at configurable rate (default 10%)
 - **Trace sampling env vars**: `QORTEX_OTEL_TRACE_SAMPLE_RATE` (default 0.1) and `QORTEX_OTEL_TRACE_LATENCY_THRESHOLD_MS` (default 100.0)
-- **Live stack validation**: `scripts/validate_live_stack.py` verifies metrics in Prometheus, traces in Jaeger, and dashboards in Grafana (132 checks)
+- **Live stack validation**: `scripts/validate_live_stack.py` verifies metrics in Prometheus, traces in Tempo, and dashboards in Grafana (132 checks)
 
 ### Removed
 

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -1,48 +1,62 @@
 # Docker Infrastructure
 
-qortex ships a Docker Compose stack for the graph database and observability services. The compose file lives at `docker/docker-compose.yml`.
+qortex ships a Docker Compose stack that includes the qortex server itself, the graph database, and full observability services. The compose file lives at `docker/docker-compose.yml`.
 
 ## Services overview
 
 | Service | Image | Purpose |
 |---------|-------|---------|
+| **qortex** | `ghcr.io/peleke/qortex:latest` | qortex REST API + MCP server. The embedding model (sentence-transformers) is baked into the image. |
 | **PostgreSQL** | `pgvector/pgvector:pg17` | Shared database for vectors, interoception, and learning state. pgvector extension pre-installed. |
 | **Memgraph** | `memgraph/memgraph-mage:latest` | Graph database (Bolt protocol). Production backend for the knowledge graph. |
 | **Memgraph Lab** | `memgraph/lab:latest` | Web UI for Memgraph. Visual graph exploration and Cypher queries. |
 | **OTel Collector** | `otel/opentelemetry-collector-contrib:latest` | Receives OTLP telemetry from qortex and routes to backends. |
-| **Jaeger** | `jaegertracing/all-in-one:latest` | Distributed trace viewer. |
+| **Tempo** | `grafana/tempo:2.7.2` | Distributed trace storage. Queried via Grafana with TraceQL. |
 | **Prometheus** | `prom/prometheus:latest` | Metrics storage and PromQL queries. |
 | **Grafana** | `grafana/grafana:latest` | Dashboard visualization. Ships with the pre-built `qortex-main` dashboard. |
 | **VictoriaLogs** | `victoriametrics/victoria-logs:latest` | Log aggregation (structured JSONL logs). 30-day retention. |
+
+> **Note**: Tempo v2.7.2 is pinned deliberately. Later versions (v2.10+) have a known partition ring issue that causes startup failures.
+
+## Running qortex
+
+qortex runs as a Docker container. The embedding model is baked into the image, so there is no separate download step and no `vec.unavailable` fallback.
+
+```bash
+# Start qortex + PostgreSQL + observability
+cd docker && docker compose up -d qortex
+
+# qortex waits for PostgreSQL to be healthy before starting.
+# Verify:
+curl -s http://localhost:8400/v1/health
+```
+
+The `qortex` service depends on `postgres` and `otel-collector`, which are started automatically. The REST API is available on port 8400 and the MCP Streamable HTTP endpoint on port 8401.
+
+### With Memgraph (full stack)
+
+```bash
+cd docker && docker compose --profile local-graph up -d qortex
+```
+
+This starts qortex, PostgreSQL, Memgraph, Memgraph Lab, and the full observability stack.
 
 ## Compose profiles
 
 The stack uses Docker Compose profiles to separate concerns:
 
-### Default profile (observability only)
+### Default (qortex + postgres + observability)
 
 ```bash
-cd docker && docker compose up -d
+cd docker && docker compose up -d qortex
 ```
 
-Starts: OTel Collector, Jaeger, Prometheus, Grafana, VictoriaLogs.
-
-Use this when Memgraph is already running elsewhere (e.g. inside a Lima sandbox VM or on a remote host).
-
-### `postgres` profile (includes PostgreSQL + pgvector)
-
-```bash
-cd docker && docker compose --profile postgres up -d
-```
-
-Starts: everything above **plus** PostgreSQL with the pgvector extension. The database is initialized with `CREATE EXTENSION IF NOT EXISTS vector` on first boot.
-
-Use this when you want persistent PostgreSQL-backed storage for vectors, learning state, and interoception state. Set `QORTEX_STORE=postgres` and `DATABASE_URL=postgresql://qortex:qortex@localhost:5432/qortex` in your shell.
+Starts: qortex, PostgreSQL, OTel Collector, Tempo, Prometheus, Grafana, VictoriaLogs.
 
 ### `local-graph` profile (includes Memgraph)
 
 ```bash
-cd docker && docker compose --profile local-graph up -d
+cd docker && docker compose --profile local-graph up -d qortex
 ```
 
 Starts: everything above **plus** Memgraph and Memgraph Lab.
@@ -51,30 +65,31 @@ Use this for standalone local development when you need the graph database on th
 
 ### When using the sandbox (Lima VM)
 
-If qortex runs inside a Lima sandbox, the VM already runs Memgraph and Lab. Lima auto-forwards the Bolt port (7687) and Lab port (3000) to the host. **Do not start the `local-graph` profile** -- you would get port conflicts. Start only the default profile for observability.
+If qortex runs inside a Lima sandbox, the VM already runs Memgraph and Lab. Lima auto-forwards the Bolt port (7687) and Lab port (3000) to the host. **Do not start the `local-graph` profile** -- you would get port conflicts. Start only the default services.
 
-### `postgres` profile (includes PostgreSQL)
+### Observability only (no qortex container)
 
-```bash
-cd docker && docker compose --profile postgres up -d
-```
-
-Starts: everything above **plus** PostgreSQL with pgvector.
-
-Use this when you want postgres-backed stores for vectors, interoception, and learning state. Combines with the default observability profile.
-
-### Full production profile
+If you want to run qortex as a bare process on the host but still use the observability stack:
 
 ```bash
-cd docker && docker compose --profile local-graph --profile postgres up -d
+cd docker && docker compose up -d otel-collector tempo prometheus grafana victorialogs
 ```
 
-Starts: all services — Memgraph, PostgreSQL, and the full observability stack.
+Then point the host qortex process at the collector:
+
+```bash
+QORTEX_OTEL_ENABLED=true \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+qortex serve
+```
 
 ## Port map
 
 | Port | Service | Protocol/UI |
 |------|---------|-------------|
+| 8400 | qortex | REST API |
+| 8401 | qortex | MCP Streamable HTTP |
 | 5432 | PostgreSQL | PostgreSQL wire protocol |
 | 7687 | Memgraph | Bolt protocol (graph queries) |
 | 7444 | Memgraph | Monitoring endpoint |
@@ -83,29 +98,32 @@ Starts: all services — Memgraph, PostgreSQL, and the full observability stack.
 | 4318 | OTel Collector | OTLP HTTP receiver |
 | 8889 | OTel Collector | Prometheus metrics (collector self-metrics) |
 | 9091 | Prometheus | Prometheus UI (mapped from container 9090 to avoid conflicts) |
-| 16686 | Jaeger | Jaeger UI |
+| 3200 | Tempo | Tempo HTTP API (TraceQL query frontend) |
 | 3010 | Grafana | Grafana UI (mapped from container 3000 to avoid Memgraph Lab conflict) |
 | 9428 | VictoriaLogs | HTTP API |
 
 ## Quick start
 
 ```bash
-# Start observability stack (no Memgraph)
-cd docker && docker compose up -d
+# Start qortex with observability
+cd docker && docker compose up -d qortex
 
-# Verify services are healthy
+# Verify qortex is healthy
+curl -s http://localhost:8400/v1/health
+
+# Verify observability services
 curl -s http://localhost:9091/api/v1/query?query=up | python3 -m json.tool
 
 # Open dashboards
 open http://localhost:3010/d/qortex-main/qortex-observability  # Grafana
-open http://localhost:16686                                      # Jaeger
+open http://localhost:3010/explore                               # Tempo traces (via Grafana Explore)
 ```
 
 With Memgraph:
 
 ```bash
 # Start everything including graph database
-cd docker && docker compose --profile local-graph up -d
+cd docker && docker compose --profile local-graph up -d qortex
 
 # Verify Memgraph
 python3 -c "import socket; s=socket.socket(); s.connect(('localhost',7687)); s.close(); print('ok')"
@@ -120,6 +138,9 @@ Set these in your shell or a `.env` file in the `docker/` directory:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `QORTEX_STORE` | `postgres` | Storage backend (`postgres` or `sqlite`). |
+| `QORTEX_GRAPH` | `memgraph` | Graph backend (`memgraph` or `memory`). |
+| `QORTEX_EXTRACTION` | `spacy` | Extraction strategy (`spacy`, `llm`, or `none`). |
 | `POSTGRES_USER` | `qortex` | PostgreSQL username. |
 | `POSTGRES_PASSWORD` | `qortex` | PostgreSQL password. |
 | `POSTGRES_DB` | `qortex` | PostgreSQL database name. |
@@ -127,52 +148,23 @@ Set these in your shell or a `.env` file in the `docker/` directory:
 | `MEMGRAPH_PASSWORD` | `memgraph` | Memgraph Bolt auth password. |
 | `GF_SECURITY_ADMIN_PASSWORD` | `qortex` | Grafana admin password. |
 
-### qortex process environment
+### qortex container environment
 
-These variables configure the qortex Python process to connect to the Docker services:
+These variables are pre-configured inside the `qortex` Docker service and typically do not need overriding:
 
 | Variable | Value | Description |
 |----------|-------|-------------|
 | `QORTEX_STORE` | `postgres` | Use PostgreSQL for vec, learning, and interoception stores. |
-| `DATABASE_URL` | `postgresql://qortex:qortex@localhost:5432/qortex` | PostgreSQL connection string for shared pool. |
+| `DATABASE_URL` | `postgresql://qortex:qortex@postgres:5432/qortex` | PostgreSQL connection string (container-internal hostname). |
 | `QORTEX_GRAPH` | `memgraph` | Use Memgraph backend (instead of in-memory). |
-| `MEMGRAPH_HOST` | `localhost` | Memgraph host (default works for local Docker). |
+| `MEMGRAPH_HOST` | `memgraph` | Memgraph container hostname. |
 | `MEMGRAPH_PORT` | `7687` | Memgraph Bolt port. |
-| `MEMGRAPH_USER` | `memgraph` | Must match the Docker env. |
-| `MEMGRAPH_PASSWORD` | `memgraph` | Must match the Docker env. |
+| `QORTEX_EXTRACTION` | `spacy` | Concept extraction via spaCy (model baked into image). |
 | `QORTEX_OTEL_ENABLED` | `true` | Enable OTel metrics and traces export. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | OTel Collector HTTP endpoint. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://otel-collector:4318` | OTel Collector HTTP endpoint (container-internal). |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` | OTLP export protocol. |
 | `QORTEX_PROMETHEUS_ENABLED` | `true` | Enable local `/metrics` endpoint for Prometheus scraping. |
 | `QORTEX_PROMETHEUS_PORT` | `9464` | Port for the local Prometheus scrape target. |
-
-### Full example (MCP server)
-
-```bash
-QORTEX_GRAPH=memgraph \
-MEMGRAPH_USER=memgraph MEMGRAPH_PASSWORD=memgraph \
-QORTEX_OTEL_ENABLED=true \
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
-OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
-QORTEX_PROMETHEUS_ENABLED=true \
-qortex mcp-serve
-```
-
-### Full example (REST API with PostgreSQL)
-
-```bash
-QORTEX_STORE=postgres \
-DATABASE_URL=postgresql://qortex:qortex@localhost:5432/qortex \
-QORTEX_GRAPH=memgraph \
-MEMGRAPH_USER=memgraph MEMGRAPH_PASSWORD=memgraph \
-QORTEX_API_KEY=my-secret-key \
-QORTEX_CORS_ORIGINS="http://localhost:3000" \
-QORTEX_OTEL_ENABLED=true \
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
-OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
-QORTEX_PROMETHEUS_ENABLED=true \
-qortex serve --host 0.0.0.0
-```
 
 ## Volumes
 
@@ -186,6 +178,7 @@ The compose file defines named volumes for persistent data:
 | `prometheus_data` | Prometheus | Metric time-series data. |
 | `victorialogs_data` | VictoriaLogs | Aggregated logs. |
 | `grafana_data` | Grafana | Dashboard state and user preferences. |
+| `tempo_data` | Tempo | Trace data (`/var/tempo`). |
 
 To reset all data:
 
@@ -196,10 +189,12 @@ cd docker && docker compose --profile local-graph down -v
 ## Grafana provisioning
 
 Grafana is pre-configured with:
-- **Datasources**: Prometheus (`http://prometheus:9090`), VictoriaLogs (`http://victorialogs:9428`).
+- **Datasources**: Prometheus (`http://prometheus:9090`), Tempo (`http://tempo:3200`), VictoriaLogs (`http://victorialogs:9428`).
 - **Dashboard**: `qortex-main` auto-loaded from `docker/grafana/dashboards/qortex.json`.
-- **Plugins**: `victoriametrics-logs-datasource`, `jdbranham-diagram-panel`.
+- **Plugins**: `victoriametrics-logs-datasource`, `jdbranham-diagram-panel`, `grafana-tempo-datasource`.
 - **Anonymous access**: enabled as Viewer (no login needed for read-only).
+
+Traces are viewable in Grafana via the Tempo datasource. Use **Explore > Tempo** to search by service name (`qortex`) or use TraceQL queries.
 
 ## Stopping services
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,6 +1,6 @@
 # Observability and Grafana Dashboard
 
-qortex includes an observability stack built on OpenTelemetry. Structured events drive metrics (Prometheus), traces (Jaeger), and a Grafana dashboard covering the entire pipeline.
+qortex includes an observability stack built on OpenTelemetry. Structured events drive metrics (Prometheus), traces (Tempo), and a Grafana dashboard covering the entire pipeline.
 
 The observability layer is packaged as `qortex-observe`, a standalone package that can be installed independently. It provides the event system, metric definitions, trace instrumentation, and subscriber wiring.
 
@@ -12,7 +12,7 @@ qortex process
   │   ├─ metrics_handlers      → OTel instruments (counters, histograms, gauges)
   │   │   ├─ OTLP push         → OTel Collector → Prometheus (remote write)
   │   │   └─ PrometheusReader  → HTTP /metrics (local scrape target, port 9464)
-  │   ├─ otel_traces           → OTel spans → Jaeger (trace viewer)
+  │   ├─ otel_traces           → OTel spans → OTel Collector → Tempo (trace storage)
   │   ├─ structlog             → stdout / JSONL sink / VictoriaLogs
   │   ├─ jsonl                 → append-only log file
   │   └─ alerts                → threshold-based alerting
@@ -54,7 +54,7 @@ open http://localhost:3010/d/qortex-main/qortex-observability
 | OTel Collector | 4317, 4318 | Receives OTLP (gRPC + HTTP) |
 | Prometheus | 9091 | Metrics storage + PromQL |
 | Grafana | 3010 | Dashboard visualization |
-| Jaeger | 16686 | Trace viewer |
+| Tempo | 3200 | Trace storage (query via Grafana Explore with TraceQL) |
 | VictoriaLogs | 9428 | Log aggregation |
 
 ## Environment Variables
@@ -455,7 +455,7 @@ When `QORTEX_STORE=postgres`, additional metrics are emitted for the PostgreSQL-
 
 ## Distributed Tracing
 
-qortex uses the `@traced` decorator from `qortex.observe.tracing` to create OpenTelemetry spans with automatic parent-child hierarchy. When OTel is enabled, every operation produces a trace tree visible in Jaeger.
+qortex uses the `@traced` decorator from `qortex.observe.tracing` to create OpenTelemetry spans with automatic parent-child hierarchy. When OTel is enabled, every operation produces a trace tree visible in Grafana via the Tempo datasource.
 
 ### Span Hierarchy
 
@@ -538,19 +538,21 @@ By default, only 10% of normal traces are exported. The `SelectiveSpanProcessor`
 
 Adjust with `QORTEX_OTEL_TRACE_SAMPLE_RATE` and `QORTEX_OTEL_TRACE_LATENCY_THRESHOLD_MS`.
 
-### Viewing Traces in Jaeger
+### Viewing Traces in Grafana (Tempo)
 
 ```bash
 # Ensure the stack is running
-cd docker && docker compose up -d
+cd docker && docker compose up -d qortex
 
-# Open Jaeger
-open http://localhost:16686
+# Open Grafana Explore with Tempo datasource
+open http://localhost:3010/explore
 
-# Select service "qortex" and search for traces
+# Select the "Tempo" datasource, search for service "qortex"
 ```
 
 Traces show the full call hierarchy: an `ingest_manifest` trace includes every `add_node`, `add_edge`, and underlying `cypher.execute` as child spans. Click any span to see its attributes (PPR convergence stats, embedding batch sizes, cache hit rates, etc.).
+
+You can use TraceQL queries for advanced filtering, e.g. `{ resource.service.name = "qortex" && span.http.status_code >= 400 }`.
 
 ## Testing the Dashboard
 

--- a/docs/guides/online-indexing.md
+++ b/docs/guides/online-indexing.md
@@ -270,9 +270,9 @@ The **Concept Extraction** section shows:
 - **Pipeline Latency (p50/p95)**: total extraction time across all chunks.
 - **Concepts by Strategy & Domain**: breakdown by extraction strategy and domain.
 
-### Jaeger traces
+### Traces (Tempo)
 
-When OTel is enabled (`QORTEX_OTEL_ENABLED=true`), each ingest call produces a trace tree:
+When OTel is enabled (`QORTEX_OTEL_ENABLED=true`), each ingest call produces a trace tree visible in Grafana via the Tempo datasource:
 
 ```
 mcp.tool.qortex_ingest_message

--- a/docs/packages/online.md
+++ b/docs/packages/online.md
@@ -195,7 +195,7 @@ class OpenAIExtractor:
 
 ## Observability
 
-Every extraction step emits OpenTelemetry spans visible in Jaeger:
+Every extraction step emits OpenTelemetry spans visible in Grafana via the Tempo datasource:
 
 ```
 extraction.spacy                    [total time]

--- a/packages/qortex-online/README.md
+++ b/packages/qortex-online/README.md
@@ -103,7 +103,7 @@ class OpenAIExtractor:
 
 ## Observability
 
-Every extraction step emits OpenTelemetry spans visible in Jaeger:
+Every extraction step emits OpenTelemetry spans visible in Grafana via the Tempo datasource:
 
 ```
 extraction.spacy                    [total time]


### PR DESCRIPTION
## Summary

- **qortex as Docker service**: Add `qortex` service to `docker-compose.yml` with REST API (8400) and MCP Streamable HTTP (8401) ports, embedding model baked into the image, and pre-configured OTEL/Prometheus/extraction env vars
- **Jaeger replaced by Tempo**: Replace `jaegertracing/all-in-one` with `grafana/tempo:2.7.2` (pinned to avoid v2.10+ partition ring bug). OTel collector now exports traces to Tempo. Grafana gets the `grafana-tempo-datasource` plugin. All docs updated to reference Grafana Explore with TraceQL instead of Jaeger UI
- **Documentation updated across 7 files**: `docs/guides/docker.md`, `docs/guides/observability.md`, `docs/guides/online-indexing.md`, `docs/packages/online.md`, `docs/changelog.md`, `packages/qortex-online/README.md`, and infrastructure config files

## Test plan

- [ ] `cd docker && docker compose up -d qortex` starts the qortex container and all dependencies
- [ ] `curl http://localhost:8400/v1/health` returns `{"status":"ok"}`
- [ ] Traces appear in Grafana Explore (Tempo datasource) after sending a query
- [ ] `docker compose --profile local-graph up -d qortex` starts Memgraph alongside qortex
- [ ] No remaining references to Jaeger in any markdown documentation files

🤖 Generated with [Claude Code](https://claude.com/claude-code)